### PR TITLE
Restore the ability to use API key

### DIFF
--- a/providers/OpenAICompatProvider.cpp
+++ b/providers/OpenAICompatProvider.cpp
@@ -77,6 +77,10 @@ void OpenAICompatProvider::prepareRequest(QJsonObject &request, LLMCore::Request
             request["frequency_penalty"] = settings.frequencyPenalty();
         if (settings.usePresencePenalty())
             request["presence_penalty"] = settings.presencePenalty();
+        const QString &apiKey = settings.apiKey();
+        if (!apiKey.isEmpty()) {
+            request["api_key"] = apiKey;
+        }
     };
 
     QJsonArray messages = prepareMessages(request);


### PR DESCRIPTION
The regression was introduced in https://github.com/Palm1r/QodeAssist/commit/bc93bce03bff3d5fe4d9d75f762514e1640dd259#diff-faab724bbfcfbc6687a3f5656c1ec01eee3bc398d533e868b2be7b71d9f6dcd5L85 which caused API key to not work.

This commit restores the ability to use API key.