### PR TITLE
fix: Make plugin registration be compatible with Qt Creator 16

### DIFF
--- a/qodeassist.cpp
+++ b/qodeassist.cpp
@@ -43,10 +43,12 @@
 
 #include "ConfigurationManager.hpp"
 #include "QodeAssistClient.hpp"
+#include "Version.hpp"
 #include "chat/ChatOutputPane.h"
 #include "chat/NavigationPanel.hpp"
 #include "settings/GeneralSettings.hpp"
 #include "settings/ProjectSettingsPanel.hpp"
+#include "settings/SettingsConstants.hpp"
 
 #include "UpdateStatusWidget.hpp"
 #include "providers/Providers.hpp"
@@ -77,6 +79,13 @@ public:
 
     void initialize() final
     {
+#if QODEASSIST_QT_CREATOR_VERSION >= QT_VERSION_CHECK(15, 0, 83)
+        Core::IOptionsPage::registerCategory(
+            Constants::QODE_ASSIST_GENERAL_OPTIONS_CATEGORY,
+            Constants::QODE_ASSIST_GENERAL_OPTIONS_DISPLAY_CATEGORY,
+            ":/resources/images/qoderassist-icon.png");
+#endif
+
         Providers::registerProviders();
         Templates::registerTemplates();
 

--- a/settings/GeneralSettings.cpp
+++ b/settings/GeneralSettings.cpp
@@ -39,6 +39,7 @@
 #include "SettingsTr.hpp"
 #include "SettingsUtils.hpp"
 #include "UpdateDialog.hpp"
+#include "../Version.hpp"
 
 namespace QodeAssist::Settings {
 
@@ -444,8 +445,10 @@ public:
         setId(Constants::QODE_ASSIST_GENERAL_SETTINGS_PAGE_ID);
         setDisplayName(TrConstants::GENERAL);
         setCategory(Constants::QODE_ASSIST_GENERAL_OPTIONS_CATEGORY);
+#if QODEASSIST_QT_CREATOR_VERSION < QT_VERSION_CHECK(15, 0, 83)
         setDisplayCategory(Constants::QODE_ASSIST_GENERAL_OPTIONS_DISPLAY_CATEGORY);
         setCategoryIconPath(":/resources/images/qoderassist-icon.png");
+#endif
         setSettingsProvider([] { return &generalSettings(); });
     }
 };


### PR DESCRIPTION
This introduces changes needed after the following commit in Qt Creator:

https://github.com/qt-creator/qt-creator/commit/ba5e4b7eff81bf84eb359df3bf5730d7a2a04588 Core: Provide settings categories centrally