### PR TITLE
chore: Run clang-format over the codebase

### DIFF
--- a/ChatView/ChatModel.cpp
+++ b/ChatView/ChatModel.cpp
@@ -18,9 +18,9 @@
  */
 
 #include "ChatModel.hpp"
+#include <utils/aspects.h>
 #include <QtCore/qjsonobject.h>
 #include <QtQml>
-#include <utils/aspects.h>
 
 #include "ChatAssistantSettings.hpp"
 
@@ -31,10 +31,11 @@ ChatModel::ChatModel(QObject *parent)
 {
     auto &settings = Settings::chatAssistantSettings();
 
-    connect(&settings.chatTokensThreshold,
-            &Utils::BaseAspect::changed,
-            this,
-            &ChatModel::tokensThresholdChanged);
+    connect(
+        &settings.chatTokensThreshold,
+        &Utils::BaseAspect::changed,
+        this,
+        &ChatModel::tokensThresholdChanged);
 }
 
 int ChatModel::rowCount(const QModelIndex &parent) const
@@ -127,7 +128,8 @@ QList<MessagePart> ChatModel::processMessageContent(const QString &content) cons
     while (blockMatches.hasNext()) {
         auto match = blockMatches.next();
         if (match.capturedStart() > lastIndex) {
-            QString textBetween = content.mid(lastIndex, match.capturedStart() - lastIndex).trimmed();
+            QString textBetween
+                = content.mid(lastIndex, match.capturedStart() - lastIndex).trimmed();
             if (!textBetween.isEmpty()) {
                 parts.append({MessagePart::Text, textBetween, ""});
             }

--- a/ChatView/ChatRootView.cpp
+++ b/ChatView/ChatRootView.cpp
@@ -24,21 +24,21 @@
 #include <QFileDialog>
 #include <QMessageBox>
 
+#include <coreplugin/editormanager/editormanager.h>
 #include <coreplugin/icore.h>
 #include <projectexplorer/project.h>
 #include <projectexplorer/projectexplorer.h>
 #include <projectexplorer/projectmanager.h>
 #include <utils/theme/theme.h>
 #include <utils/utilsicons.h>
-#include <coreplugin/editormanager/editormanager.h>
 
 #include "ChatAssistantSettings.hpp"
 #include "ChatSerializer.hpp"
 #include "GeneralSettings.hpp"
 #include "Logger.hpp"
 #include "ProjectSettings.hpp"
-#include "context/TokenUtils.hpp"
 #include "context/ContextManager.hpp"
+#include "context/TokenUtils.hpp"
 
 namespace QodeAssist::Chat {
 
@@ -48,18 +48,16 @@ ChatRootView::ChatRootView(QQuickItem *parent)
     , m_clientInterface(new ClientInterface(m_chatModel, this))
 {
     m_isSyncOpenFiles = Settings::chatAssistantSettings().linkOpenFiles();
-    connect(&Settings::chatAssistantSettings().linkOpenFiles, &Utils::BaseAspect::changed,
-            this,
-            [this](){
-                setIsSyncOpenFiles(Settings::chatAssistantSettings().linkOpenFiles());
-            });
+    connect(
+        &Settings::chatAssistantSettings().linkOpenFiles,
+        &Utils::BaseAspect::changed,
+        this,
+        [this]() { setIsSyncOpenFiles(Settings::chatAssistantSettings().linkOpenFiles()); });
 
     auto &settings = Settings::generalSettings();
 
-    connect(&settings.caModel,
-            &Utils::BaseAspect::changed,
-            this,
-            &ChatRootView::currentTemplateChanged);
+    connect(
+        &settings.caModel, &Utils::BaseAspect::changed, this, &ChatRootView::currentTemplateChanged);
 
     connect(
         m_clientInterface,
@@ -76,10 +74,16 @@ ChatRootView::ChatRootView(QQuickItem *parent)
     connect(m_chatModel, &ChatModel::modelReseted, this, [this]() { setRecentFilePath(QString{}); });
     connect(this, &ChatRootView::attachmentFilesChanged, &ChatRootView::updateInputTokensCount);
     connect(this, &ChatRootView::linkedFilesChanged, &ChatRootView::updateInputTokensCount);
-    connect(&Settings::chatAssistantSettings().useSystemPrompt, &Utils::BaseAspect::changed,
-            this, &ChatRootView::updateInputTokensCount);
-    connect(&Settings::chatAssistantSettings().systemPrompt, &Utils::BaseAspect::changed,
-            this, &ChatRootView::updateInputTokensCount);
+    connect(
+        &Settings::chatAssistantSettings().useSystemPrompt,
+        &Utils::BaseAspect::changed,
+        this,
+        &ChatRootView::updateInputTokensCount);
+    connect(
+        &Settings::chatAssistantSettings().systemPrompt,
+        &Utils::BaseAspect::changed,
+        this,
+        &ChatRootView::updateInputTokensCount);
 
     auto editors = Core::EditorManager::instance();
 
@@ -450,7 +454,7 @@ void ChatRootView::openChatHistoryFolder()
 void ChatRootView::updateInputTokensCount()
 {
     int inputTokens = m_messageTokensCount;
-    auto& settings = Settings::chatAssistantSettings();
+    auto &settings = Settings::chatAssistantSettings();
 
     if (settings.useSystemPrompt()) {
         inputTokens += Context::TokenUtils::estimateTokens(settings.systemPrompt());
@@ -466,8 +470,8 @@ void ChatRootView::updateInputTokensCount()
         inputTokens += Context::TokenUtils::estimateFilesTokens(linkFiles);
     }
 
-    const auto& history = m_chatModel->getChatHistory();
-    for (const auto& message : history) {
+    const auto &history = m_chatModel->getChatHistory();
+    for (const auto &message : history) {
         inputTokens += Context::TokenUtils::estimateTokens(message.content);
         inputTokens += 4; // + role
     }

--- a/ChatView/ChatWidget.cpp
+++ b/ChatView/ChatWidget.cpp
@@ -40,4 +40,4 @@ void ChatWidget::scrollToBottom()
 {
     QMetaObject::invokeMethod(rootObject(), "scrollToBottom");
 }
-}
+} // namespace QodeAssist::Chat

--- a/ChatView/ChatWidget.hpp
+++ b/ChatView/ChatWidget.hpp
@@ -38,4 +38,4 @@ signals:
     void clearPressed();
 };
 
-}
+} // namespace QodeAssist::Chat

--- a/ChatView/ClientInterface.cpp
+++ b/ChatView/ClientInterface.cpp
@@ -19,11 +19,11 @@
 
 #include "ClientInterface.hpp"
 
+#include <texteditor/textdocument.h>
 #include <QFileInfo>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QUuid>
-#include <texteditor/textdocument.h>
 
 #include <coreplugin/editormanager/editormanager.h>
 #include <coreplugin/editormanager/ieditor.h>
@@ -46,21 +46,23 @@ ClientInterface::ClientInterface(ChatModel *chatModel, QObject *parent)
     , m_requestHandler(new LLMCore::RequestHandler(this))
     , m_chatModel(chatModel)
 {
-    connect(m_requestHandler,
-            &LLMCore::RequestHandler::completionReceived,
-            this,
-            [this](const QString &completion, const QJsonObject &request, bool isComplete) {
-                handleLLMResponse(completion, request, isComplete);
-            });
+    connect(
+        m_requestHandler,
+        &LLMCore::RequestHandler::completionReceived,
+        this,
+        [this](const QString &completion, const QJsonObject &request, bool isComplete) {
+            handleLLMResponse(completion, request, isComplete);
+        });
 
-    connect(m_requestHandler,
-            &LLMCore::RequestHandler::requestFinished,
-            this,
-            [this](const QString &, bool success, const QString &errorString) {
-                if (!success) {
-                    emit errorOccurred(errorString);
-                }
-            });
+    connect(
+        m_requestHandler,
+        &LLMCore::RequestHandler::requestFinished,
+        this,
+        [this](const QString &, bool success, const QString &errorString) {
+            if (!success) {
+                emit errorOccurred(errorString);
+            }
+        });
 }
 
 ClientInterface::~ClientInterface() = default;
@@ -149,9 +151,8 @@ void ClientInterface::cancelRequest()
     m_requestHandler->cancelRequest(id);
 }
 
-void ClientInterface::handleLLMResponse(const QString &response,
-                                        const QJsonObject &request,
-                                        bool isComplete)
+void ClientInterface::handleLLMResponse(
+    const QString &response, const QJsonObject &request, bool isComplete)
 {
     const auto message = response.trimmed();
 
@@ -191,7 +192,8 @@ QString ClientInterface::getCurrentFileContext() const
     return QString("Current file context:\n%1\nFile content:\n%2").arg(fileInfo, content);
 }
 
-QString ClientInterface::getSystemPromptWithLinkedFiles(const QString &basePrompt, const QList<QString> &linkedFiles) const
+QString ClientInterface::getSystemPromptWithLinkedFiles(
+    const QString &basePrompt, const QList<QString> &linkedFiles) const
 {
     QString updatedPrompt = basePrompt;
 
@@ -200,8 +202,7 @@ QString ClientInterface::getSystemPromptWithLinkedFiles(const QString &basePromp
 
         auto contentFiles = Context::ContextManager::instance().getContentFiles(linkedFiles);
         for (const auto &file : contentFiles) {
-            updatedPrompt += QString("\nFile: %1\nContent:\n%2\n")
-            .arg(file.filename, file.content);
+            updatedPrompt += QString("\nFile: %1\nContent:\n%2\n").arg(file.filename, file.content);
         }
     }
 

--- a/ChatView/ClientInterface.hpp
+++ b/ChatView/ClientInterface.hpp
@@ -51,8 +51,7 @@ private:
     void handleLLMResponse(const QString &response, const QJsonObject &request, bool isComplete);
     QString getCurrentFileContext() const;
     QString getSystemPromptWithLinkedFiles(
-        const QString &basePrompt,
-        const QList<QString> &linkedFiles) const;
+        const QString &basePrompt, const QList<QString> &linkedFiles) const;
 
     LLMCore::RequestHandler *m_requestHandler;
     ChatModel *m_chatModel;

--- a/ConfigurationManager.cpp
+++ b/ConfigurationManager.cpp
@@ -19,8 +19,8 @@
 
 #include "ConfigurationManager.hpp"
 
-#include <QTimer>
 #include <settings/ButtonAspect.hpp>
+#include <QTimer>
 
 #include "QodeAssisttr.h"
 
@@ -111,10 +111,8 @@ void ConfigurationManager::selectProvider()
                                : m_generalSettings.caProvider;
 
     QTimer::singleShot(0, this, [this, providersList, &targetSettings] {
-        m_generalSettings.showSelectionDialog(providersList,
-                                              targetSettings,
-                                              Tr::tr("Select LLM Provider"),
-                                              Tr::tr("Providers:"));
+        m_generalSettings.showSelectionDialog(
+            providersList, targetSettings, Tr::tr("Select LLM Provider"), Tr::tr("Providers:"));
     });
 }
 
@@ -181,10 +179,8 @@ void ConfigurationManager::selectTemplate()
                                             : m_generalSettings.caTemplate;
 
     QTimer::singleShot(0, &m_generalSettings, [this, templateList, &targetSettings]() {
-        m_generalSettings.showSelectionDialog(templateList,
-                                              targetSettings,
-                                              Tr::tr("Select Template"),
-                                              Tr::tr("Templates:"));
+        m_generalSettings.showSelectionDialog(
+            templateList, targetSettings, Tr::tr("Select Template"), Tr::tr("Templates:"));
     });
 }
 

--- a/LLMClientInterface.cpp
+++ b/LLMClientInterface.cpp
@@ -40,10 +40,11 @@ namespace QodeAssist {
 LLMClientInterface::LLMClientInterface()
     : m_requestHandler(this)
 {
-    connect(&m_requestHandler,
-            &LLMCore::RequestHandler::completionReceived,
-            this,
-            &LLMClientInterface::sendCompletionToClient);
+    connect(
+        &m_requestHandler,
+        &LLMCore::RequestHandler::completionReceived,
+        this,
+        &LLMClientInterface::sendCompletionToClient);
 }
 
 Utils::FilePath LLMClientInterface::serverDeviceTemplate() const
@@ -204,10 +205,11 @@ void LLMClientInterface::handleCompletion(const QJsonObject &request)
 
     QString systemPrompt;
     if (completeSettings.useSystemPrompt())
-        systemPrompt.append(completeSettings.useUserMessageTemplateForCC()
-                                    && promptTemplate->type() == LLMCore::TemplateType::Chat
-                                ? completeSettings.systemPromptForNonFimModels()
-                                : completeSettings.systemPrompt());
+        systemPrompt.append(
+            completeSettings.useUserMessageTemplateForCC()
+                    && promptTemplate->type() == LLMCore::TemplateType::Chat
+                ? completeSettings.systemPromptForNonFimModels()
+                : completeSettings.systemPrompt());
     if (updatedContext.fileContext.has_value())
         systemPrompt.append(updatedContext.fileContext.value());
 
@@ -243,8 +245,8 @@ void LLMClientInterface::handleCompletion(const QJsonObject &request)
     m_requestHandler.sendLLMRequest(config, request);
 }
 
-LLMCore::ContextData LLMClientInterface::prepareContext(const QJsonObject &request,
-                                                        const QStringView &accumulatedCompletion)
+LLMCore::ContextData LLMClientInterface::prepareContext(
+    const QJsonObject &request, const QStringView &accumulatedCompletion)
 {
     QJsonObject params = request["params"].toObject();
     QJsonObject doc = params["doc"].toObject();
@@ -267,9 +269,8 @@ LLMCore::ContextData LLMClientInterface::prepareContext(const QJsonObject &reque
     return reader.prepareContext(lineNumber, cursorPosition);
 }
 
-void LLMClientInterface::sendCompletionToClient(const QString &completion,
-                                                const QJsonObject &request,
-                                                bool isComplete)
+void LLMClientInterface::sendCompletionToClient(
+    const QString &completion, const QJsonObject &request, bool isComplete)
 {
     bool isPreset1Active = Context::ContextManager::instance().isSpecifyCompletion(request);
 
@@ -294,8 +295,8 @@ void LLMClientInterface::sendCompletionToClient(const QString &completion,
     QString processedCompletion
         = promptTemplate->type() == LLMCore::TemplateType::Chat
                   && Settings::codeCompletionSettings().smartProcessInstuctText()
-                                      ? CodeHandler::processText(completion)
-                                      : completion;
+              ? CodeHandler::processText(completion)
+              : completion;
 
     completionItem[LanguageServerProtocol::textKey] = processedCompletion;
     QJsonObject range;
@@ -312,7 +313,8 @@ void LLMClientInterface::sendCompletionToClient(const QString &completion,
         QString("Completions: \n%1")
             .arg(QString::fromUtf8(QJsonDocument(completions).toJson(QJsonDocument::Indented))));
 
-    LOG_MESSAGE(QString("Full response: \n%1")
+    LOG_MESSAGE(
+        QString("Full response: \n%1")
             .arg(QString::fromUtf8(QJsonDocument(response).toJson(QJsonDocument::Indented))));
 
     QString requestId = request["id"].toString();
@@ -336,9 +338,8 @@ void LLMClientInterface::endTimeMeasurement(const QString &requestId)
     }
 }
 
-void LLMClientInterface::logPerformance(const QString &requestId,
-                                        const QString &operation,
-                                        qint64 elapsedMs)
+void LLMClientInterface::logPerformance(
+    const QString &requestId, const QString &operation, qint64 elapsedMs)
 {
     LOG_MESSAGE(QString("Performance: %1 %2 took %3 ms").arg(requestId, operation).arg(elapsedMs));
 }

--- a/LLMClientInterface.hpp
+++ b/LLMClientInterface.hpp
@@ -40,9 +40,8 @@ public:
 
     Utils::FilePath serverDeviceTemplate() const override;
 
-    void sendCompletionToClient(const QString &completion,
-                                const QJsonObject &request,
-                                bool isComplete);
+    void sendCompletionToClient(
+        const QString &completion, const QJsonObject &request, bool isComplete);
 
     void handleCompletion(const QJsonObject &request);
 

--- a/LSPCompletion.hpp
+++ b/LSPCompletion.hpp
@@ -68,9 +68,10 @@ class GetCompletionParams : public LanguageServerProtocol::JsonObject
 public:
     static constexpr LanguageServerProtocol::Key docKey{"doc"};
 
-    GetCompletionParams(const LanguageServerProtocol::TextDocumentIdentifier &document,
-                        int version,
-                        const LanguageServerProtocol::Position &position)
+    GetCompletionParams(
+        const LanguageServerProtocol::TextDocumentIdentifier &document,
+        int version,
+        const LanguageServerProtocol::Position &position)
     {
         setTextDocument(document);
         setVersion(version);

--- a/QodeAssistClient.cpp
+++ b/QodeAssistClient.cpp
@@ -147,9 +147,10 @@ void QodeAssistClient::requestCompletions(TextEditor::TextEditorWidget *editor)
         return;
 
     const FilePath filePath = editor->textDocument()->filePath();
-    GetCompletionRequest request{{TextDocumentIdentifier(hostPathToServerUri(filePath)),
-                                  documentVersion(filePath),
-                                  Position(cursor.mainCursor())}};
+    GetCompletionRequest request{
+        {TextDocumentIdentifier(hostPathToServerUri(filePath)),
+         documentVersion(filePath),
+         Position(cursor.mainCursor())}};
     request.setResponseCallback([this, editor = QPointer<TextEditorWidget>(editor)](
                                     const GetCompletionRequest::Response &response) {
         QTC_ASSERT(editor, return);
@@ -188,8 +189,8 @@ void QodeAssistClient::scheduleRequest(TextEditor::TextEditorWidget *editor)
     it.value()->setProperty("cursorPosition", editor->textCursor().position());
     it.value()->start(Settings::codeCompletionSettings().startSuggestionTimer());
 }
-void QodeAssistClient::handleCompletions(const GetCompletionRequest::Response &response,
-                                         TextEditor::TextEditorWidget *editor)
+void QodeAssistClient::handleCompletions(
+    const GetCompletionRequest::Response &response, TextEditor::TextEditorWidget *editor)
 {
     if (response.error())
         log(*response.error());
@@ -267,18 +268,13 @@ void QodeAssistClient::setupConnections()
             openDocument(textDocument);
     };
 
-    m_documentOpenedConnection = connect(EditorManager::instance(),
-                                         &EditorManager::documentOpened,
-                                         this,
-                                         openDoc);
-    m_documentClosedConnection = connect(EditorManager::instance(),
-                                         &EditorManager::documentClosed,
-                                         this,
-                                         [this](IDocument *document) {
-                                             if (auto textDocument = qobject_cast<TextDocument *>(
-                                                     document))
-                                                 closeDocument(textDocument);
-                                         });
+    m_documentOpenedConnection
+        = connect(EditorManager::instance(), &EditorManager::documentOpened, this, openDoc);
+    m_documentClosedConnection = connect(
+        EditorManager::instance(), &EditorManager::documentClosed, this, [this](IDocument *document) {
+            if (auto textDocument = qobject_cast<TextDocument *>(document))
+                closeDocument(textDocument);
+        });
 
     for (IDocument *doc : DocumentModel::openedDocuments())
         openDoc(doc);

--- a/QodeAssistClient.hpp
+++ b/QodeAssistClient.hpp
@@ -43,8 +43,8 @@ public:
 
 private:
     void scheduleRequest(TextEditor::TextEditorWidget *editor);
-    void handleCompletions(const GetCompletionRequest::Response &response,
-                           TextEditor::TextEditorWidget *editor);
+    void handleCompletions(
+        const GetCompletionRequest::Response &response, TextEditor::TextEditorWidget *editor);
     void cancelRunningRequest(TextEditor::TextEditorWidget *editor);
     bool isEnabled(ProjectExplorer::Project *project) const;
 

--- a/chat/NavigationPanel.cpp
+++ b/chat/NavigationPanel.cpp
@@ -23,16 +23,15 @@
 
 namespace QodeAssist::Chat {
 
-NavigationPanel::NavigationPanel() {
+NavigationPanel::NavigationPanel()
+{
     setDisplayName(tr("QodeAssist Chat"));
     setPriority(500);
     setId("QodeAssistChat");
     setActivationSequence(QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_C));
 }
 
-NavigationPanel::~NavigationPanel()
-{
-}
+NavigationPanel::~NavigationPanel() {}
 
 Core::NavigationView NavigationPanel::createWidget()
 {
@@ -42,4 +41,4 @@ Core::NavigationView NavigationPanel::createWidget()
     return view;
 }
 
-}
+} // namespace QodeAssist::Chat

--- a/chat/NavigationPanel.hpp
+++ b/chat/NavigationPanel.hpp
@@ -19,8 +19,8 @@
 
 #pragma once
 
-#include <QObject>
 #include <coreplugin/inavigationwidgetfactory.h>
+#include <QObject>
 
 namespace QodeAssist::Chat {
 
@@ -34,4 +34,4 @@ public:
     Core::NavigationView createWidget() override;
 };
 
-}
+} // namespace QodeAssist::Chat

--- a/context/ChangesManager.cpp
+++ b/context/ChangesManager.cpp
@@ -30,17 +30,12 @@ ChangesManager &ChangesManager::instance()
 
 ChangesManager::ChangesManager()
     : QObject(nullptr)
-{
-}
+{}
 
-ChangesManager::~ChangesManager()
-{
-}
+ChangesManager::~ChangesManager() {}
 
-void ChangesManager::addChange(TextEditor::TextDocument *document,
-                               int position,
-                               int charsRemoved,
-                               int charsAdded)
+void ChangesManager::addChange(
+    TextEditor::TextDocument *document, int position, int charsRemoved, int charsAdded)
 {
     auto &documentQueue = m_documentChanges[document];
 
@@ -51,9 +46,10 @@ void ChangesManager::addChange(TextEditor::TextDocument *document,
 
     ChangeInfo change{fileName, lineNumber, lineContent};
 
-    auto it = std::find_if(documentQueue.begin(),
-                           documentQueue.end(),
-                           [lineNumber](const ChangeInfo &c) { return c.lineNumber == lineNumber; });
+    auto it
+        = std::find_if(documentQueue.begin(), documentQueue.end(), [lineNumber](const ChangeInfo &c) {
+              return c.lineNumber == lineNumber;
+          });
 
     if (it != documentQueue.end()) {
         it->lineContent = lineContent;

--- a/context/ChangesManager.h
+++ b/context/ChangesManager.h
@@ -19,11 +19,11 @@
 
 #pragma once
 
+#include <texteditor/textdocument.h>
 #include <QDateTime>
 #include <QHash>
 #include <QQueue>
 #include <QTimer>
-#include <texteditor/textdocument.h>
 
 namespace QodeAssist::Context {
 
@@ -41,10 +41,8 @@ public:
 
     static ChangesManager &instance();
 
-    void addChange(TextEditor::TextDocument *document,
-                   int position,
-                   int charsRemoved,
-                   int charsAdded);
+    void addChange(
+        TextEditor::TextDocument *document, int position, int charsRemoved, int charsAdded);
     QString getRecentChangesContext(const TextEditor::TextDocument *currentDocument) const;
 
 private:

--- a/context/DocumentContextReader.cpp
+++ b/context/DocumentContextReader.cpp
@@ -19,9 +19,9 @@
 
 #include "DocumentContextReader.hpp"
 
+#include <languageserverprotocol/lsptypes.h>
 #include <QFileInfo>
 #include <QTextBlock>
-#include <languageserverprotocol/lsptypes.h>
 
 #include "CodeCompletionSettings.hpp"
 
@@ -41,9 +41,8 @@ const QRegularExpression &getNameRegex()
 
 const QRegularExpression &getCommentRegex()
 {
-    static const QRegularExpression
-        commentRegex(R"((/\*[\s\S]*?\*/|//.*$|#.*$|//{2,}[\s\S]*?//{2,}))",
-                     QRegularExpression::MultilineOption);
+    static const QRegularExpression commentRegex(
+        R"((/\*[\s\S]*?\*/|//.*$|#.*$|//{2,}[\s\S]*?//{2,}))", QRegularExpression::MultilineOption);
     return commentRegex;
 }
 
@@ -80,9 +79,8 @@ QString DocumentContextReader::getLineText(int lineNumber, int cursorPosition) c
     return QString();
 }
 
-QString DocumentContextReader::getContextBefore(int lineNumber,
-                                                int cursorPosition,
-                                                int linesCount) const
+QString DocumentContextReader::getContextBefore(
+    int lineNumber, int cursorPosition, int linesCount) const
 {
     int effectiveStartLine;
     if (m_copyrightInfo.found) {
@@ -94,9 +92,8 @@ QString DocumentContextReader::getContextBefore(int lineNumber,
     return getContextBetween(effectiveStartLine, lineNumber, cursorPosition);
 }
 
-QString DocumentContextReader::getContextAfter(int lineNumber,
-                                               int cursorPosition,
-                                               int linesCount) const
+QString DocumentContextReader::getContextAfter(
+    int lineNumber, int cursorPosition, int linesCount) const
 {
     int endLine = qMin(m_document->blockCount() - 1, lineNumber + linesCount);
     return getContextBetween(lineNumber + 1, endLine, cursorPosition);
@@ -179,9 +176,7 @@ CopyrightInfo DocumentContextReader::findCopyright()
     return result;
 }
 
-QString DocumentContextReader::getContextBetween(int startLine,
-                                                 int endLine,
-                                                 int cursorPosition) const
+QString DocumentContextReader::getContextBetween(int startLine, int endLine, int cursorPosition) const
 {
     QString context;
     for (int i = startLine; i <= endLine; ++i) {
@@ -240,8 +235,9 @@ QString DocumentContextReader::getContextAfter(int lineNumber, int cursorPositio
     if (Settings::codeCompletionSettings().readFullFile()) {
         return readWholeFileAfter(lineNumber, cursorPosition);
     } else {
-        int endLine = qMin(m_document->blockCount() - 1,
-                           lineNumber + Settings::codeCompletionSettings().readStringsAfterCursor());
+        int endLine = qMin(
+            m_document->blockCount() - 1,
+            lineNumber + Settings::codeCompletionSettings().readStringsAfterCursor());
         return getContextBetween(lineNumber + 1, endLine, -1);
     }
 }

--- a/context/TokenUtils.cpp
+++ b/context/TokenUtils.cpp
@@ -21,7 +21,7 @@
 
 namespace QodeAssist::Context {
 
-int TokenUtils::estimateTokens(const QString& text)
+int TokenUtils::estimateTokens(const QString &text)
 {
     if (text.isEmpty()) {
         return 0;
@@ -31,7 +31,7 @@ int TokenUtils::estimateTokens(const QString& text)
     return text.length() / 4;
 }
 
-int TokenUtils::estimateFileTokens(const Context::ContentFile& file)
+int TokenUtils::estimateFileTokens(const Context::ContentFile &file)
 {
     int total = 0;
 
@@ -42,13 +42,13 @@ int TokenUtils::estimateFileTokens(const Context::ContentFile& file)
     return total;
 }
 
-int TokenUtils::estimateFilesTokens(const QList<Context::ContentFile>& files)
+int TokenUtils::estimateFilesTokens(const QList<Context::ContentFile> &files)
 {
     int total = 0;
-    for (const auto& file : files) {
+    for (const auto &file : files) {
         total += estimateFileTokens(file);
     }
     return total;
 }
 
-}
+} // namespace QodeAssist::Context

--- a/context/TokenUtils.hpp
+++ b/context/TokenUtils.hpp
@@ -19,18 +19,18 @@
 
 #pragma once
 
-#include <QString>
 #include "ContentFile.hpp"
 #include <QList>
+#include <QString>
 
 namespace QodeAssist::Context {
 
 class TokenUtils
 {
 public:
-    static int estimateTokens(const QString& text);
-    static int estimateFileTokens(const Context::ContentFile& file);
-    static int estimateFilesTokens(const QList<Context::ContentFile>& files);
+    static int estimateTokens(const QString &text);
+    static int estimateFileTokens(const Context::ContentFile &file);
+    static int estimateFilesTokens(const QList<Context::ContentFile> &files);
 };
 
-}
+} // namespace QodeAssist::Context

--- a/llmcore/PromptTemplateManager.hpp
+++ b/llmcore/PromptTemplateManager.hpp
@@ -35,8 +35,7 @@ public:
     template<typename T>
     void registerTemplate()
     {
-        static_assert(std::is_base_of<PromptTemplate, T>::value,
-                      "T must inherit from PromptTemplate");
+        static_assert(std::is_base_of<PromptTemplate, T>::value, "T must inherit from PromptTemplate");
         T *template_ptr = new T();
         QString name = template_ptr->name();
         m_fimTemplates[name] = template_ptr;

--- a/llmcore/ProvidersManager.hpp
+++ b/llmcore/ProvidersManager.hpp
@@ -21,8 +21,8 @@
 
 #include <QString>
 
-#include <QMap>
 #include "Provider.hpp"
+#include <QMap>
 
 namespace QodeAssist::LLMCore {
 

--- a/llmcore/RequestConfig.hpp
+++ b/llmcore/RequestConfig.hpp
@@ -19,11 +19,11 @@
 
 #pragma once
 
-#include <QJsonObject>
-#include <QUrl>
 #include "PromptTemplate.hpp"
 #include "Provider.hpp"
 #include "RequestType.hpp"
+#include <QJsonObject>
+#include <QUrl>
 
 namespace QodeAssist::LLMCore {
 

--- a/llmcore/RequestHandler.cpp
+++ b/llmcore/RequestHandler.cpp
@@ -33,15 +33,16 @@ RequestHandler::RequestHandler(QObject *parent)
 void RequestHandler::sendLLMRequest(const LLMConfig &config, const QJsonObject &request)
 {
     LOG_MESSAGE(QString("Sending request to llm: \nurl: %1\nRequest body:\n%2")
-                   .arg(config.url.toString(),
+                    .arg(
+                        config.url.toString(),
                         QString::fromUtf8(
                             QJsonDocument(config.providerRequest).toJson(QJsonDocument::Indented))));
 
     QNetworkRequest networkRequest(config.url);
     config.provider->prepareNetworkRequest(networkRequest);
 
-    QNetworkReply *reply = m_manager->post(networkRequest,
-                                           QJsonDocument(config.providerRequest).toJson());
+    QNetworkReply *reply
+        = m_manager->post(networkRequest, QJsonDocument(config.providerRequest).toJson());
     if (!reply) {
         LOG_MESSAGE("Error: Failed to create network reply");
         return;
@@ -70,9 +71,8 @@ void RequestHandler::sendLLMRequest(const LLMConfig &config, const QJsonObject &
     });
 }
 
-void RequestHandler::handleLLMResponse(QNetworkReply *reply,
-                                       const QJsonObject &request,
-                                       const LLMConfig &config)
+void RequestHandler::handleLLMResponse(
+    QNetworkReply *reply, const QJsonObject &request, const LLMConfig &config)
 {
     QString &accumulatedResponse = m_accumulatedResponses[reply];
 
@@ -85,8 +85,8 @@ void RequestHandler::handleLLMResponse(QNetworkReply *reply,
         }
 
         if (isComplete) {
-            auto cleanedCompletion = removeStopWords(accumulatedResponse,
-                                                     config.promptTemplate->stopWords());
+            auto cleanedCompletion
+                = removeStopWords(accumulatedResponse, config.promptTemplate->stopWords());
 
             emit completionReceived(cleanedCompletion, request, true);
         }

--- a/llmcore/RequestHandler.hpp
+++ b/llmcore/RequestHandler.hpp
@@ -37,9 +37,7 @@ public:
     explicit RequestHandler(QObject *parent = nullptr);
 
     void sendLLMRequest(const LLMConfig &config, const QJsonObject &request);
-    void handleLLMResponse(QNetworkReply *reply,
-                           const QJsonObject &request,
-                           const LLMConfig &config);
+    void handleLLMResponse(QNetworkReply *reply, const QJsonObject &request, const LLMConfig &config);
     bool cancelRequest(const QString &id);
 
 signals:
@@ -52,10 +50,11 @@ private:
     QMap<QString, QNetworkReply *> m_activeRequests;
     QMap<QNetworkReply *, QString> m_accumulatedResponses;
 
-    bool processSingleLineCompletion(QNetworkReply *reply,
-                                     const QJsonObject &request,
-                                     const QString &accumulatedResponse,
-                                     const LLMConfig &config);
+    bool processSingleLineCompletion(
+        QNetworkReply *reply,
+        const QJsonObject &request,
+        const QString &accumulatedResponse,
+        const LLMConfig &config);
     QString removeStopWords(const QStringView &completion, const QStringList &stopWords);
     void removeCodeBlockWrappers(QString &response);
 };

--- a/providers/OllamaProvider.cpp
+++ b/providers/OllamaProvider.cpp
@@ -112,9 +112,8 @@ bool OllamaProvider::handleResponse(QNetworkReply *reply, QString &accumulatedRe
         }
 
         const QString endpoint = reply->url().path();
-        auto messageType = endpoint == completionEndpoint()
-                               ? LLMCore::OllamaMessage::Type::Generate
-                               : LLMCore::OllamaMessage::Type::Chat;
+        auto messageType = endpoint == completionEndpoint() ? LLMCore::OllamaMessage::Type::Generate
+                                                            : LLMCore::OllamaMessage::Type::Chat;
 
         auto message = LLMCore::OllamaMessage::fromJson(line, messageType);
         if (message.hasError()) {

--- a/settings/ButtonAspect.hpp
+++ b/settings/ButtonAspect.hpp
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include <QPushButton>
 #include <utils/aspects.h>
 #include <utils/layoutbuilder.h>
+#include <QPushButton>
 
 class ButtonAspect : public Utils::BaseAspect
 {

--- a/settings/ChatAssistantSettings.cpp
+++ b/settings/ChatAssistantSettings.cpp
@@ -19,10 +19,10 @@
 
 #include "ChatAssistantSettings.hpp"
 
-#include <QMessageBox>
 #include <coreplugin/dialogs/ioptionspage.h>
 #include <coreplugin/icore.h>
 #include <utils/layoutbuilder.h>
+#include <QMessageBox>
 
 #include "SettingsConstants.hpp"
 #include "SettingsTr.hpp"
@@ -195,10 +195,11 @@ ChatAssistantSettings::ChatAssistantSettings()
 
 void ChatAssistantSettings::setupConnections()
 {
-    connect(&resetToDefaults,
-            &ButtonAspect::clicked,
-            this,
-            &ChatAssistantSettings::resetSettingsToDefaults);
+    connect(
+        &resetToDefaults,
+        &ButtonAspect::clicked,
+        this,
+        &ChatAssistantSettings::resetSettingsToDefaults);
 }
 
 void ChatAssistantSettings::resetSettingsToDefaults()

--- a/settings/CodeCompletionSettings.cpp
+++ b/settings/CodeCompletionSettings.cpp
@@ -19,10 +19,10 @@
 
 #include "CodeCompletionSettings.hpp"
 
-#include <QMessageBox>
 #include <coreplugin/dialogs/ioptionspage.h>
 #include <coreplugin/icore.h>
 #include <utils/layoutbuilder.h>
+#include <QMessageBox>
 
 #include "SettingsConstants.hpp"
 #include "SettingsTr.hpp"
@@ -250,17 +250,18 @@ CodeCompletionSettings::CodeCompletionSettings()
         contextGrid.addRow({Row{readFullFile}});
         contextGrid.addRow({Row{readFileParts, readStringsBeforeCursor, readStringsAfterCursor}});
 
-        auto contextItem = Column{Row{contextGrid, Stretch{1}},
-                                  Row{useSystemPrompt, Stretch{1}},
-                                  Group{title(Tr::tr("Prompts for FIM models")),
-                                        Column{systemPrompt}},
-                                  Group{title(Tr::tr("Prompts for Non FIM models")),
-                                        Column{
-                                            Row{useUserMessageTemplateForCC, Stretch{1}},
-                                            systemPromptForNonFimModels,
-                                            userMessageTemplateForCC,
-                                        }},
-                                  Row{useProjectChangesCache, maxChangesCacheSize, Stretch{1}}};
+        auto contextItem = Column{
+            Row{contextGrid, Stretch{1}},
+            Row{useSystemPrompt, Stretch{1}},
+            Group{title(Tr::tr("Prompts for FIM models")), Column{systemPrompt}},
+            Group{
+                title(Tr::tr("Prompts for Non FIM models")),
+                Column{
+                    Row{useUserMessageTemplateForCC, Stretch{1}},
+                    systemPromptForNonFimModels,
+                    userMessageTemplateForCC,
+                }},
+            Row{useProjectChangesCache, maxChangesCacheSize, Stretch{1}}};
 
         return Column{
             Row{Stretch{1}, resetToDefaults},
@@ -297,10 +298,11 @@ CodeCompletionSettings::CodeCompletionSettings()
 
 void CodeCompletionSettings::setupConnections()
 {
-    connect(&resetToDefaults,
-            &ButtonAspect::clicked,
-            this,
-            &CodeCompletionSettings::resetSettingsToDefaults);
+    connect(
+        &resetToDefaults,
+        &ButtonAspect::clicked,
+        this,
+        &CodeCompletionSettings::resetSettingsToDefaults);
 
     connect(&readFullFile, &Utils::BoolAspect::volatileValueChanged, this, [this]() {
         if (readFullFile.volatileValue()) {

--- a/settings/CustomPromptSettings.cpp
+++ b/settings/CustomPromptSettings.cpp
@@ -19,12 +19,12 @@
 
 #include "CustomPromptSettings.hpp"
 
-#include <QFileDialog>
-#include <QJsonParseError>
-#include <QMessageBox>
 #include <coreplugin/dialogs/ioptionspage.h>
 #include <coreplugin/icore.h>
 #include <utils/layoutbuilder.h>
+#include <QFileDialog>
+#include <QJsonParseError>
+#include <QMessageBox>
 
 #include "SettingsConstants.hpp"
 #include "SettingsTr.hpp"
@@ -86,30 +86,36 @@ CustomPromptSettings::CustomPromptSettings()
 
     setLayouter([this]() {
         using namespace Layouting;
-        return Column{Group{title(Tr::tr("Custom prompt for FIM model")),
-                            Column{Row{customJsonLabel, Stretch{1}, resetToDefaults},
-                                   Row{customJsonTemplate,
-                                       Column{saveCustomTemplateButton,
-                                              loadCustomTemplateButton,
-                                              customJsonLegend,
-                                              Stretch{1}}}}}};
+        return Column{Group{
+            title(Tr::tr("Custom prompt for FIM model")),
+            Column{
+                Row{customJsonLabel, Stretch{1}, resetToDefaults},
+                Row{customJsonTemplate,
+                    Column{
+                        saveCustomTemplateButton,
+                        loadCustomTemplateButton,
+                        customJsonLegend,
+                        Stretch{1}}}}}};
     });
 }
 
 void CustomPromptSettings::setupConnection()
 {
-    connect(&resetToDefaults,
-            &ButtonAspect::clicked,
-            this,
-            &CustomPromptSettings::resetSettingsToDefaults);
-    connect(&saveCustomTemplateButton,
-            &ButtonAspect::clicked,
-            this,
-            &CustomPromptSettings::saveCustomTemplate);
-    connect(&loadCustomTemplateButton,
-            &ButtonAspect::clicked,
-            this,
-            &CustomPromptSettings::loadCustomTemplate);
+    connect(
+        &resetToDefaults,
+        &ButtonAspect::clicked,
+        this,
+        &CustomPromptSettings::resetSettingsToDefaults);
+    connect(
+        &saveCustomTemplateButton,
+        &ButtonAspect::clicked,
+        this,
+        &CustomPromptSettings::saveCustomTemplate);
+    connect(
+        &loadCustomTemplateButton,
+        &ButtonAspect::clicked,
+        this,
+        &CustomPromptSettings::loadCustomTemplate);
 }
 
 void CustomPromptSettings::resetSettingsToDefaults()
@@ -128,10 +134,8 @@ void CustomPromptSettings::resetSettingsToDefaults()
 
 void CustomPromptSettings::saveCustomTemplate()
 {
-    QString fileName = QFileDialog::getSaveFileName(nullptr,
-                                                    Tr::tr("Save JSON Template"),
-                                                    QString(),
-                                                    Tr::tr("JSON Files (*.json)"));
+    QString fileName = QFileDialog::getSaveFileName(
+        nullptr, Tr::tr("Save JSON Template"), QString(), Tr::tr("JSON Files (*.json)"));
     if (fileName.isEmpty())
         return;
 
@@ -140,22 +144,19 @@ void CustomPromptSettings::saveCustomTemplate()
         QTextStream out(&file);
         out << customJsonTemplate.value();
         file.close();
-        QMessageBox::information(nullptr,
-                                 Tr::tr("Save Successful"),
-                                 Tr::tr("JSON template has been saved successfully."));
+        QMessageBox::information(
+            nullptr,
+            Tr::tr("Save Successful"),
+            Tr::tr("JSON template has been saved successfully."));
     } else {
-        QMessageBox::critical(nullptr,
-                              Tr::tr("Save Failed"),
-                              Tr::tr("Failed to save JSON template."));
+        QMessageBox::critical(nullptr, Tr::tr("Save Failed"), Tr::tr("Failed to save JSON template."));
     }
 }
 
 void CustomPromptSettings::loadCustomTemplate()
 {
-    QString fileName = QFileDialog::getOpenFileName(nullptr,
-                                                    Tr::tr("Load JSON Template"),
-                                                    QString(),
-                                                    Tr::tr("JSON Files (*.json)"));
+    QString fileName = QFileDialog::getOpenFileName(
+        nullptr, Tr::tr("Load JSON Template"), QString(), Tr::tr("JSON Files (*.json)"));
     if (fileName.isEmpty())
         return;
 
@@ -169,18 +170,16 @@ void CustomPromptSettings::loadCustomTemplate()
         QJsonDocument jsonDoc = QJsonDocument::fromJson(jsonContent.toUtf8(), &parseError);
         if (parseError.error == QJsonParseError::NoError) {
             customJsonTemplate.setVolatileValue(jsonContent);
-            QMessageBox::information(nullptr,
-                                     Tr::tr("Load Successful"),
-                                     Tr::tr("JSON template has been loaded successfully."));
+            QMessageBox::information(
+                nullptr,
+                Tr::tr("Load Successful"),
+                Tr::tr("JSON template has been loaded successfully."));
         } else {
-            QMessageBox::critical(nullptr,
-                                  Tr::tr("Invalid JSON"),
-                                  Tr::tr("The selected file contains invalid JSON."));
+            QMessageBox::critical(
+                nullptr, Tr::tr("Invalid JSON"), Tr::tr("The selected file contains invalid JSON."));
         }
     } else {
-        QMessageBox::critical(nullptr,
-                              Tr::tr("Load Failed"),
-                              Tr::tr("Failed to load JSON template."));
+        QMessageBox::critical(nullptr, Tr::tr("Load Failed"), Tr::tr("Failed to load JSON template."));
     }
 }
 

--- a/settings/GeneralSettings.cpp
+++ b/settings/GeneralSettings.cpp
@@ -392,16 +392,17 @@ void GeneralSettings::setupConnections()
 
     connect(&specifyPreset1, &Utils::BoolAspect::volatileValueChanged, this, [this]() {
         updatePreset1Visiblity(specifyPreset1.volatileValue());
-    });    
+    });
 }
 
 void GeneralSettings::resetPageToDefaults()
 {
     QMessageBox::StandardButton reply;
-    reply = QMessageBox::question(Core::ICore::dialogParent(),
-                                  TrConstants::RESET_SETTINGS,
-                                  TrConstants::CONFIRMATION,
-                                  QMessageBox::Yes | QMessageBox::No);
+    reply = QMessageBox::question(
+        Core::ICore::dialogParent(),
+        TrConstants::RESET_SETTINGS,
+        TrConstants::CONFIRMATION,
+        QMessageBox::Yes | QMessageBox::No);
 
     if (reply == QMessageBox::Yes) {
         resetAspect(enableQodeAssist);

--- a/settings/GeneralSettings.hpp
+++ b/settings/GeneralSettings.hpp
@@ -94,10 +94,11 @@ public:
 
     Utils::StringAspect caTemplateDescription{this};
 
-    void showSelectionDialog(const QStringList &data,
-                             Utils::StringAspect &aspect,
-                             const QString &title = {},
-                             const QString &text = {});
+    void showSelectionDialog(
+        const QStringList &data,
+        Utils::StringAspect &aspect,
+        const QString &title = {},
+        const QString &text = {});
 
     void showModelsNotFoundDialog(Utils::StringAspect &aspect);
 

--- a/settings/SettingsTr.hpp
+++ b/settings/SettingsTr.hpp
@@ -26,8 +26,8 @@ namespace QodeAssist::Settings {
 namespace TrConstants {
 inline const char *ENABLE_QODE_ASSIST = QT_TRANSLATE_NOOP("QtC::QodeAssist", "Enable Qode Assist");
 inline const char *GENERAL = QT_TRANSLATE_NOOP("QtC::QodeAssist", "General");
-inline const char *RESET_TO_DEFAULTS = QT_TRANSLATE_NOOP("QtC::QodeAssist",
-                                                         "Reset Page to Defaults");
+inline const char *RESET_TO_DEFAULTS
+    = QT_TRANSLATE_NOOP("QtC::QodeAssist", "Reset Page to Defaults");
 inline const char *CHECK_UPDATE = QT_TRANSLATE_NOOP("QtC::QodeAssist", "Check Update");
 inline const char *SELECT = QT_TRANSLATE_NOOP("QtC::QodeAssist", "Select...");
 inline const char *PROVIDER = QT_TRANSLATE_NOOP("QtC::QodeAssist", "Provider:");
@@ -46,9 +46,8 @@ inline const char *ENABLE_CHAT = QT_TRANSLATE_NOOP(
 inline const char *CODE_COMPLETION = QT_TRANSLATE_NOOP("QtC::QodeAssist", "Code Completion");
 inline const char *CHAT_ASSISTANT = QT_TRANSLATE_NOOP("QtC::QodeAssist", "Chat Assistant");
 inline const char *RESET_SETTINGS = QT_TRANSLATE_NOOP("QtC::QodeAssist", "Reset Settings");
-inline const char *CONFIRMATION
-    = QT_TRANSLATE_NOOP("QtC::QodeAssist",
-                        "Are you sure you want to reset all settings to default values?");
+inline const char *CONFIRMATION = QT_TRANSLATE_NOOP(
+    "QtC::QodeAssist", "Are you sure you want to reset all settings to default values?");
 inline const char *CURRENT_TEMPLATE_DESCRIPTION
     = QT_TRANSLATE_NOOP("QtC::QodeAssist", "Current template description:");
 

--- a/settings/SettingsUtils.hpp
+++ b/settings/SettingsUtils.hpp
@@ -19,13 +19,13 @@
 
 #pragma once
 
+#include <utils/aspects.h>
+#include <utils/layoutbuilder.h>
 #include <QCoreApplication>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QPushButton>
 #include <QtCore/qtimer.h>
-#include <utils/aspects.h>
-#include <utils/layoutbuilder.h>
 
 namespace QodeAssist::Settings {
 
@@ -67,10 +67,11 @@ void resetAspect(AspectType &aspect)
     aspect.setVolatileValue(aspect.defaultValue());
 }
 
-inline void initStringAspect(Utils::StringAspect &aspect,
-                             const Utils::Key &settingsKey,
-                             const QString &labelText,
-                             const QString &defaultValue)
+inline void initStringAspect(
+    Utils::StringAspect &aspect,
+    const Utils::Key &settingsKey,
+    const QString &labelText,
+    const QString &defaultValue)
 {
     aspect.setSettingsKey(settingsKey);
     aspect.setLabelText(labelText);

--- a/templates/CustomFimTemplate.hpp
+++ b/templates/CustomFimTemplate.hpp
@@ -77,8 +77,8 @@ private:
         return value;
     }
 
-    QJsonObject processJsonTemplate(const QJsonObject &templateObj,
-                                    const LLMCore::ContextData &context) const
+    QJsonObject processJsonTemplate(
+        const QJsonObject &templateObj, const LLMCore::ContextData &context) const
     {
         QJsonObject result;
         for (auto it = templateObj.begin(); it != templateObj.end(); ++it) {

--- a/templates/Qwen.hpp
+++ b/templates/Qwen.hpp
@@ -19,8 +19,8 @@
 
 #pragma once
 
-#include <QJsonArray>
 #include "llmcore/PromptTemplate.hpp"
+#include <QJsonArray>
 
 namespace QodeAssist::Templates {
 


### PR DESCRIPTION
I noticed instruction to follow .clang-format in README when preparing another PR. After running clang-format-19 on files I changed I saw unrelated changes. I thought that it probably makes sense to reformat whole codebase. Then the contributors can be told to forget about formatting and simply run clang-format after each commit.

Or this PR can be closed if the project owner likes hybrid approach better :-)


This PR is a result of the following commands:

```
clang-format-19 --style=file -i $(git ls-files | fgrep .cpp) 
clang-format-19 --style=file -i $(git ls-files | fgrep .hpp)
```

