### PR TITLE
fix: Make settings dialogs button order consistent

### DIFF
--- a/settings/GeneralSettings.cpp
+++ b/settings/GeneralSettings.cpp
@@ -42,6 +42,17 @@
 
 namespace QodeAssist::Settings {
 
+void addDialogButtons(QBoxLayout *layout, QAbstractButton *okButton, QAbstractButton *cancelButton)
+{
+#if defined(Q_OS_MACOS)
+    layout->addWidget(cancelButton);
+    layout->addWidget(okButton);
+#else
+    layout->addWidget(okButton);
+    layout->addWidget(cancelButton);
+#endif
+}
+
 GeneralSettings &generalSettings()
 {
     static GeneralSettings settings;
@@ -321,8 +332,7 @@ void GeneralSettings::showModelsNotSupportedDialog(Utils::StringAspect &aspect)
     auto cancelButton = new QPushButton(TrConstants::CANCEL);
     connect(cancelButton, &QPushButton::clicked, &dialog, &QDialog::reject);
 
-    dialog.buttonLayout()->addWidget(cancelButton);
-    dialog.buttonLayout()->addWidget(okButton);
+    addDialogButtons(dialog.buttonLayout(), okButton, cancelButton);
 
     modelList->setFocus();
     dialog.exec();
@@ -361,8 +371,7 @@ void GeneralSettings::showUrlSelectionDialog(
     auto cancelButton = new QPushButton(TrConstants::CANCEL);
     connect(cancelButton, &QPushButton::clicked, &dialog, &QDialog::reject);
 
-    dialog.buttonLayout()->addWidget(cancelButton);
-    dialog.buttonLayout()->addWidget(okButton);
+    addDialogButtons(dialog.buttonLayout(), okButton, cancelButton);
 
     urlList->setFocus();
     dialog.exec();


### PR DESCRIPTION
Currently most dialogs follow the following order of action buttons: "OK", "Cancel" (left to right). However, several dialogs are constructed explicitly and don't follow this convention.

This commit fixes this discrepancy.

Fixes: https://github.com/Palm1r/QodeAssist/issues/83

New screenshot:

![image](https://github.com/user-attachments/assets/af38e565-2c84-460e-aaaa-b00d8446a249)
