### PR TITLE
fix: Add tooltip about where log messages can be seen

### DIFF
--- a/settings/GeneralSettings.cpp
+++ b/settings/GeneralSettings.cpp
@@ -60,6 +60,7 @@ GeneralSettings::GeneralSettings()
 
     enableLogging.setSettingsKey(Constants::ENABLE_LOGGING);
     enableLogging.setLabelText(TrConstants::ENABLE_LOG);
+    enableLogging.setToolTip(TrConstants::ENABLE_LOG_TOOLTIP);
     enableLogging.setDefaultValue(false);
 
     enableCheckUpdate.setSettingsKey(Constants::ENABLE_CHECK_UPDATE);

--- a/settings/SettingsTr.hpp
+++ b/settings/SettingsTr.hpp
@@ -37,6 +37,8 @@ inline const char *URL = QT_TRANSLATE_NOOP("QtC::QodeAssist", "URL:");
 inline const char *STATUS = QT_TRANSLATE_NOOP("QtC::QodeAssist", "Status:");
 inline const char *TEST = QT_TRANSLATE_NOOP("QtC::QodeAssist", "Test");
 inline const char *ENABLE_LOG = QT_TRANSLATE_NOOP("QtC::QodeAssist", "Enable Logging");
+inline const char *ENABLE_LOG_TOOLTIP
+    = QT_TRANSLATE_NOOP("QtC::QodeAssist", "Log messages are visible in General Messages pane");
 inline const char *ENABLE_CHECK_UPDATE_ON_START
     = QT_TRANSLATE_NOOP("QtC::QodeAssist", "Check for updates when Qt Creator starts");
 inline const char *ENABLE_CHAT = QT_TRANSLATE_NOOP(


### PR DESCRIPTION
It is possible to waste a lot of time searching for log messages, because Qt Creator already has a logging system which can be reached by going Tools > Debug Qt Creator > Show Logs. Adding a tooltip makes it possible to avoid this without introducing additional visual clutter.