### PR TITLE
refactor: Make DocumentContextReader usable outside Qt Creator context

### DIFF
--- a/LLMClientInterface.cpp
+++ b/LLMClientInterface.cpp
@@ -265,7 +265,8 @@ LLMCore::ContextData LLMClientInterface::prepareContext(
     int cursorPosition = position["character"].toInt();
     int lineNumber = position["line"].toInt();
 
-    Context::DocumentContextReader reader(textDocument);
+    Context::DocumentContextReader reader(
+        textDocument->document(), textDocument->mimeType(), textDocument->filePath().toString());
     return reader.prepareContext(lineNumber, cursorPosition);
 }
 

--- a/context/DocumentContextReader.cpp
+++ b/context/DocumentContextReader.cpp
@@ -48,9 +48,11 @@ const QRegularExpression &getCommentRegex()
 
 namespace QodeAssist::Context {
 
-DocumentContextReader::DocumentContextReader(TextEditor::TextDocument *textDocument)
-    : m_textDocument(textDocument)
-    , m_document(textDocument->document())
+DocumentContextReader::DocumentContextReader(
+    QTextDocument *document, const QString &mimeType, const QString &filePath)
+    : m_document(document)
+    , m_mimeType(mimeType)
+    , m_filePath(filePath)
 {
     m_copyrightInfo = findCopyright();
 }
@@ -120,17 +122,11 @@ QString DocumentContextReader::readWholeFileAfter(int lineNumber, int cursorPosi
 
 QString DocumentContextReader::getLanguageAndFileInfo() const
 {
-    if (!m_textDocument)
-        return QString();
-
-    QString language = LanguageServerProtocol::TextDocumentItem::mimeTypeToLanguageId(
-        m_textDocument->mimeType());
-    QString mimeType = m_textDocument->mimeType();
-    QString filePath = m_textDocument->filePath().toString();
-    QString fileExtension = QFileInfo(filePath).suffix();
+    QString language = LanguageServerProtocol::TextDocumentItem::mimeTypeToLanguageId(m_mimeType);
+    QString fileExtension = QFileInfo(m_filePath).suffix();
 
     return QString("Language: %1 (MIME: %2) filepath: %3(%4)\n\n")
-        .arg(language, mimeType, filePath, fileExtension);
+        .arg(language, m_mimeType, m_filePath, fileExtension);
 }
 
 CopyrightInfo DocumentContextReader::findCopyright()

--- a/context/DocumentContextReader.hpp
+++ b/context/DocumentContextReader.hpp
@@ -36,7 +36,8 @@ struct CopyrightInfo
 class DocumentContextReader
 {
 public:
-    DocumentContextReader(TextEditor::TextDocument *textDocument);
+    DocumentContextReader(
+        QTextDocument *m_document, const QString &mimeType, const QString &filePath);
 
     QString getLineText(int lineNumber, int cursorPosition = -1) const;
     QString getContextBefore(int lineNumber, int cursorPosition, int linesCount) const;
@@ -58,6 +59,8 @@ private:
 private:
     TextEditor::TextDocument *m_textDocument;
     QTextDocument *m_document;
+    QString m_mimeType;
+    QString m_filePath;
     CopyrightInfo m_copyrightInfo;
 };
 


### PR DESCRIPTION
This makes it possible to write simple unit tests for it without running full Qt Creator. Not coupling DocumentContextReader to TextEditor::TextDocument unnecessarily is also a better design in general.