### PR TITLE
chore: Run clang-format over the codebase

### DIFF
--- a/settings/GeneralSettings.cpp
+++ b/settings/GeneralSettings.cpp
@@ -33,13 +33,13 @@
 #include <QtWidgets/qradiobutton.h>
 #include <QtWidgets/qstackedwidget.h>
 
+#include "../Version.hpp"
 #include "Logger.hpp"
 #include "SettingsConstants.hpp"
 #include "SettingsDialog.hpp"
 #include "SettingsTr.hpp"
 #include "SettingsUtils.hpp"
 #include "UpdateDialog.hpp"
-#include "../Version.hpp"
 
 namespace QodeAssist::Settings {
 


### PR DESCRIPTION
Sorry for not formatting one of my past commits.

I will add formatting check as part of CI in separate PR.

This commit is a result of the following commands:

```
clang-format-19 --style=file -i $(git ls-files | fgrep .cpp) 
clang-format-19 --style=file -i $(git ls-files | fgrep .hpp)
```