### PR TITLE
chore: Add Github Actions job for checking formatting

### DIFF
--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -1,0 +1,24 @@
+name: Check formatting
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-format-19
+    - name: Check formatting
+      run: |
+        clang-format-19 --style=file -i $(git ls-files | fgrep .hpp)
+        clang-format-19 --style=file -i $(git ls-files | fgrep .cpp)
+        git diff --exit-code || exit 1


### PR DESCRIPTION
This ensures that broken formatting is not accidentally merged. This would break user workflow because then they cannot format their code without introducing unrelated changes.