### PR TITLE
refactor: Make DocumentContextReader::prepareContext() testable

### DIFF
--- a/LLMClientInterface.cpp
+++ b/LLMClientInterface.cpp
@@ -267,7 +267,7 @@ LLMCore::ContextData LLMClientInterface::prepareContext(
 
     Context::DocumentContextReader reader(
         textDocument->document(), textDocument->mimeType(), textDocument->filePath().toString());
-    return reader.prepareContext(lineNumber, cursorPosition);
+    return reader.prepareContext(lineNumber, cursorPosition, Settings::codeCompletionSettings());
 }
 
 void LLMClientInterface::sendCompletionToClient(

--- a/context/DocumentContextReader.hpp
+++ b/context/DocumentContextReader.hpp
@@ -23,6 +23,7 @@
 #include <QTextDocument>
 
 #include <llmcore/ContextData.hpp>
+#include <settings/CodeCompletionSettings.hpp>
 
 namespace QodeAssist::Context {
 
@@ -72,11 +73,8 @@ public:
 
     CopyrightInfo copyrightInfo() const;
 
-    LLMCore::ContextData prepareContext(int lineNumber, int cursorPosition) const;
-
-private:
-    QString getContextBefore(int lineNumber, int cursorPosition) const;
-    QString getContextAfter(int lineNumber, int cursorPosition) const;
+    LLMCore::ContextData prepareContext(
+        int lineNumber, int cursorPosition, const Settings::CodeCompletionSettings &settings) const;
 
 private:
     TextEditor::TextDocument *m_textDocument;

--- a/llmcore/ContextData.hpp
+++ b/llmcore/ContextData.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2024 Petr Mironychev
  *
  * This file is part of QodeAssist.
@@ -28,6 +28,10 @@ struct Message
 {
     QString role;
     QString content;
+
+    // clang-format off
+    auto operator<=>(const Message&) const = default;
+    // clang-format on
 };
 
 struct ContextData
@@ -37,6 +41,8 @@ struct ContextData
     std::optional<QString> suffix;
     std::optional<QString> fileContext;
     std::optional<QVector<Message>> history;
+
+    bool operator==(const ContextData &) const = default;
 };
 
 } // namespace QodeAssist::LLMCore


### PR DESCRIPTION
This involves inlining getContextBefore() and getContextAfter() which contained relatively simple and duplicated logic and exposing code completion settings to the caller. This allows writing tests for prepareContext() which was done in this commit.

The tests recovered that I changed meaning of `linesCount` after all in previous PR, so callers will need adjustments. I will fix this in next PR as this is refactoring commit.