### PR TITLE
fix: Bring back old behavior of readStrings{After,Before}Cursor setting 

### DIFF
--- a/context/DocumentContextReader.cpp
+++ b/context/DocumentContextReader.cpp
@@ -253,10 +253,12 @@ LLMCore::ContextData DocumentContextReader::prepareContext(
         contextBefore = readWholeFileBefore(lineNumber, cursorPosition);
         contextAfter = readWholeFileAfter(lineNumber, cursorPosition);
     } else {
+        // Note that readStrings{After,Before}Cursor include current line, but linesCount argument of
+        // getContext{After,Before} do not
         contextBefore
-            = getContextBefore(lineNumber, cursorPosition, settings.readStringsBeforeCursor());
+            = getContextBefore(lineNumber, cursorPosition, settings.readStringsBeforeCursor() + 1);
         contextAfter
-            = getContextAfter(lineNumber, cursorPosition, settings.readStringsAfterCursor());
+            = getContextAfter(lineNumber, cursorPosition, settings.readStringsAfterCursor() + 1);
     }
 
     QString fileContext;

--- a/test/DocumentContextReaderTest.cpp
+++ b/test/DocumentContextReaderTest.cpp
@@ -283,15 +283,15 @@ TEST_F(DocumentContextReaderTest, testPrepareContext)
     EXPECT_EQ(
         reader.prepareContext(2, 3, *createSettingsForLines(1, 1)),
         (ContextData{
-            .prefix = "Lin",
-            .suffix = "e 3",
+            .prefix = "Line 2\nLin",
+            .suffix = "e 3\nLine 4",
             .fileContext = "\n Language:  (MIME: text/python) filepath: /path/to/file()\n\n\n "}));
 
     EXPECT_EQ(
         reader.prepareContext(2, 3, *createSettingsForLines(2, 2)),
         (ContextData{
-            .prefix = "Line 2\nLin",
-            .suffix = "e 3\nLine 4",
+            .prefix = "Line 1\nLine 2\nLin",
+            .suffix = "e 3\nLine 4\nLine 5",
             .fileContext = "\n Language:  (MIME: text/python) filepath: /path/to/file()\n\n\n "}));
 }
 


### PR DESCRIPTION
A previous commit changed what linesCount argument of getContext{After,Before} meant. The callers relied on the old meaning. This commit fixes this.

Fixes: https://github.com/Palm1r/QodeAssist/commit/3dc0d910bfaf3bd56eaec3bd476631a471b36109