### PR TITLE
fix: Properly omit copyright information

### DIFF
--- a/context/DocumentContextReader.hpp
+++ b/context/DocumentContextReader.hpp
@@ -81,6 +81,11 @@ private:
     QTextDocument *m_document;
     QString m_mimeType;
     QString m_filePath;
+
+    // Used to omit copyright headers from context. If context would otherwise include copyright
+    // header it is excluded by deleting it from the returned context. This means, that the
+    // returned context may contain less information than requested. If the cursor is within copyright
+    // header, then the context may be empty if the context window is small.
     CopyrightInfo m_copyrightInfo;
 };
 

--- a/test/DocumentContextReaderTest.cpp
+++ b/test/DocumentContextReaderTest.cpp
@@ -166,7 +166,7 @@ TEST_F(DocumentContextReaderTest, testGetContextWithCopyright)
 
     // Unknown cursor position
     EXPECT_EQ(reader.getContextBefore(0, -1, 2), "");
-    EXPECT_EQ(reader.getContextAfter(0, -1, 2), "/* Copyright (C) 2024 */\nLine 0");
+    EXPECT_EQ(reader.getContextAfter(0, -1, 2), "Line 0");
 
     EXPECT_EQ(reader.getContextBefore(1, -1, 2), "Line 0");
     EXPECT_EQ(reader.getContextAfter(1, -1, 2), "Line 0\nLine 1");
@@ -179,7 +179,7 @@ TEST_F(DocumentContextReaderTest, testGetContextWithCopyright)
 
     // Known cursor position
     EXPECT_EQ(reader.getContextBefore(0, 1, 2), "");
-    EXPECT_EQ(reader.getContextAfter(0, 1, 2), "* Copyright (C) 2024 */\nLine 0");
+    EXPECT_EQ(reader.getContextAfter(0, 1, 2), "Line 0");
 
     EXPECT_EQ(reader.getContextBefore(1, 1, 2), "L");
     EXPECT_EQ(reader.getContextAfter(1, 1, 2), "ine 0\nLine 1");
@@ -232,10 +232,8 @@ TEST_F(DocumentContextReaderTest, testReadWholeFileWithCopyright)
 {
     auto reader = createTestReader("/* Copyright (C) 2024 */\nLine 0\nLine 1\nLine 2\nLine 3");
     // Unknown cursor position
-    EXPECT_EQ(reader.readWholeFileBefore(0, -1), "/* Copyright (C) 2024 */");
-    EXPECT_EQ(
-        reader.readWholeFileAfter(0, -1),
-        "/* Copyright (C) 2024 */\nLine 0\nLine 1\nLine 2\nLine 3");
+    EXPECT_EQ(reader.readWholeFileBefore(0, -1), "");
+    EXPECT_EQ(reader.readWholeFileAfter(0, -1), "Line 0\nLine 1\nLine 2\nLine 3");
 
     EXPECT_EQ(reader.readWholeFileBefore(1, -1), "Line 0");
     EXPECT_EQ(reader.readWholeFileAfter(1, -1), "Line 0\nLine 1\nLine 2\nLine 3");
@@ -248,8 +246,7 @@ TEST_F(DocumentContextReaderTest, testReadWholeFileWithCopyright)
 
     // Known cursor position
     EXPECT_EQ(reader.readWholeFileBefore(0, 0), "");
-    EXPECT_EQ(
-        reader.readWholeFileAfter(0, 0), "/* Copyright (C) 2024 */\nLine 0\nLine 1\nLine 2\nLine 3");
+    EXPECT_EQ(reader.readWholeFileAfter(0, 0), "Line 0\nLine 1\nLine 2\nLine 3");
 
     EXPECT_EQ(reader.readWholeFileBefore(1, 0), "");
     EXPECT_EQ(reader.readWholeFileAfter(1, 0), "Line 0\nLine 1\nLine 2\nLine 3");
@@ -260,9 +257,8 @@ TEST_F(DocumentContextReaderTest, testReadWholeFileWithCopyright)
     EXPECT_EQ(reader.readWholeFileBefore(3, 0), "Line 0\nLine 1\n");
     EXPECT_EQ(reader.readWholeFileAfter(3, 0), "Line 2\nLine 3");
 
-    EXPECT_EQ(reader.readWholeFileBefore(0, 1), "/");
-    EXPECT_EQ(
-        reader.readWholeFileAfter(0, 1), "* Copyright (C) 2024 */\nLine 0\nLine 1\nLine 2\nLine 3");
+    EXPECT_EQ(reader.readWholeFileBefore(0, 1), "");
+    EXPECT_EQ(reader.readWholeFileAfter(0, 1), "Line 0\nLine 1\nLine 2\nLine 3");
 
     EXPECT_EQ(reader.readWholeFileBefore(1, 1), "L");
     EXPECT_EQ(reader.readWholeFileAfter(1, 1), "ine 0\nLine 1\nLine 2\nLine 3");
@@ -281,72 +277,87 @@ TEST_F(DocumentContextReaderTest, testReadWholeFileWithMultilineCopyright)
         "Line 0\nLine 1\nLine 2\nLine 3");
 
     // Unknown cursor position
-    EXPECT_EQ(reader.readWholeFileBefore(0, -1), "/*");
-    EXPECT_EQ(
-        reader.readWholeFileAfter(0, -1),
-        "/*\n * Copyright (C) 2024\n * \n * This file is part of QodeAssist.\n */\nLine 0\nLine "
-        "1\nLine 2\nLine 3");
+    EXPECT_EQ(reader.readWholeFileBefore(0, -1), "");
+    EXPECT_EQ(reader.readWholeFileAfter(0, -1), "Line 0\nLine 1\nLine 2\nLine 3");
 
-    EXPECT_EQ(reader.readWholeFileBefore(1, -1), " * Copyright (C) 2024");
-    EXPECT_EQ(
-        reader.readWholeFileAfter(1, -1),
-        " * Copyright (C) 2024\n * \n * This file is part of QodeAssist.\n */\nLine 0\nLine "
-        "1\nLine 2\nLine 3");
+    EXPECT_EQ(reader.readWholeFileBefore(1, -1), "");
+    EXPECT_EQ(reader.readWholeFileAfter(1, -1), "Line 0\nLine 1\nLine 2\nLine 3");
 
-    EXPECT_EQ(reader.readWholeFileBefore(2, -1), " * ");
-    EXPECT_EQ(
-        reader.readWholeFileAfter(2, -1),
-        " * \n * This file is part of QodeAssist.\n */\nLine 0\nLine 1\nLine 2\nLine 3");
+    EXPECT_EQ(reader.readWholeFileBefore(2, -1), "");
+    EXPECT_EQ(reader.readWholeFileAfter(2, -1), "Line 0\nLine 1\nLine 2\nLine 3");
 
-    EXPECT_EQ(reader.readWholeFileBefore(3, -1), " * This file is part of QodeAssist.");
-    EXPECT_EQ(
-        reader.readWholeFileAfter(3, -1),
-        " * This file is part of QodeAssist.\n */\nLine 0\nLine 1\nLine 2\nLine 3");
+    EXPECT_EQ(reader.readWholeFileBefore(3, -1), "");
+    EXPECT_EQ(reader.readWholeFileAfter(3, -1), "Line 0\nLine 1\nLine 2\nLine 3");
+
+    EXPECT_EQ(reader.readWholeFileBefore(4, -1), "");
+    EXPECT_EQ(reader.readWholeFileAfter(4, -1), "Line 0\nLine 1\nLine 2\nLine 3");
+
+    EXPECT_EQ(reader.readWholeFileBefore(5, -1), "Line 0");
+    EXPECT_EQ(reader.readWholeFileAfter(5, -1), "Line 0\nLine 1\nLine 2\nLine 3");
+
+    EXPECT_EQ(reader.readWholeFileBefore(6, -1), "Line 0\nLine 1");
+    EXPECT_EQ(reader.readWholeFileAfter(6, -1), "Line 1\nLine 2\nLine 3");
+
+    EXPECT_EQ(reader.readWholeFileBefore(7, -1), "Line 0\nLine 1\nLine 2");
+    EXPECT_EQ(reader.readWholeFileAfter(7, -1), "Line 2\nLine 3");
+
+    EXPECT_EQ(reader.readWholeFileBefore(8, -1), "Line 0\nLine 1\nLine 2\nLine 3");
+    EXPECT_EQ(reader.readWholeFileAfter(8, -1), "Line 3");
 
     // Known cursor position
     EXPECT_EQ(reader.readWholeFileBefore(0, 0), "");
-    EXPECT_EQ(
-        reader.readWholeFileAfter(0, 0),
-        "/*\n * Copyright (C) 2024\n * \n * This file is part of QodeAssist.\n */\nLine 0\nLine "
-        "1\nLine 2\nLine 3");
+    EXPECT_EQ(reader.readWholeFileAfter(0, 0), "Line 0\nLine 1\nLine 2\nLine 3");
 
     EXPECT_EQ(reader.readWholeFileBefore(1, 0), "");
-    EXPECT_EQ(
-        reader.readWholeFileAfter(1, 0),
-        " * Copyright (C) 2024\n * \n * This file is part of QodeAssist.\n */\nLine 0\nLine "
-        "1\nLine 2\nLine 3");
+    EXPECT_EQ(reader.readWholeFileAfter(1, 0), "Line 0\nLine 1\nLine 2\nLine 3");
 
     EXPECT_EQ(reader.readWholeFileBefore(2, 0), "");
-    EXPECT_EQ(
-        reader.readWholeFileAfter(2, 0),
-        " * \n * This file is part of QodeAssist.\n */\nLine 0\nLine 1\nLine 2\nLine 3");
+    EXPECT_EQ(reader.readWholeFileAfter(2, 0), "Line 0\nLine 1\nLine 2\nLine 3");
 
     EXPECT_EQ(reader.readWholeFileBefore(3, 0), "");
-    EXPECT_EQ(
-        reader.readWholeFileAfter(3, 0),
-        " * This file is part of QodeAssist.\n */\nLine 0\nLine 1\nLine 2\nLine 3");
+    EXPECT_EQ(reader.readWholeFileAfter(3, 0), "Line 0\nLine 1\nLine 2\nLine 3");
 
-    EXPECT_EQ(reader.readWholeFileBefore(0, 1), "/");
-    EXPECT_EQ(
-        reader.readWholeFileAfter(0, 1),
-        "*\n * Copyright (C) 2024\n * \n * This file is part of QodeAssist.\n */\nLine 0\nLine "
-        "1\nLine 2\nLine 3");
+    EXPECT_EQ(reader.readWholeFileBefore(4, 0), "");
+    EXPECT_EQ(reader.readWholeFileAfter(4, 0), "Line 0\nLine 1\nLine 2\nLine 3");
 
-    EXPECT_EQ(reader.readWholeFileBefore(1, 1), " ");
-    EXPECT_EQ(
-        reader.readWholeFileAfter(1, 1),
-        "* Copyright (C) 2024\n * \n * This file is part of QodeAssist.\n */\nLine 0\nLine 1\nLine "
-        "2\nLine 3");
+    EXPECT_EQ(reader.readWholeFileBefore(5, 0), "");
+    EXPECT_EQ(reader.readWholeFileAfter(5, 0), "Line 0\nLine 1\nLine 2\nLine 3");
 
-    EXPECT_EQ(reader.readWholeFileBefore(2, 1), " ");
-    EXPECT_EQ(
-        reader.readWholeFileAfter(2, 1),
-        "* \n * This file is part of QodeAssist.\n */\nLine 0\nLine 1\nLine 2\nLine 3");
+    EXPECT_EQ(reader.readWholeFileBefore(6, 0), "Line 0\n");
+    EXPECT_EQ(reader.readWholeFileAfter(6, 0), "Line 1\nLine 2\nLine 3");
 
-    EXPECT_EQ(reader.readWholeFileBefore(3, 1), " ");
-    EXPECT_EQ(
-        reader.readWholeFileAfter(3, 1),
-        "* This file is part of QodeAssist.\n */\nLine 0\nLine 1\nLine 2\nLine 3");
+    EXPECT_EQ(reader.readWholeFileBefore(7, 0), "Line 0\nLine 1\n");
+    EXPECT_EQ(reader.readWholeFileAfter(7, 0), "Line 2\nLine 3");
+
+    EXPECT_EQ(reader.readWholeFileBefore(8, 0), "Line 0\nLine 1\nLine 2\n");
+    EXPECT_EQ(reader.readWholeFileAfter(8, 0), "Line 3");
+
+    EXPECT_EQ(reader.readWholeFileBefore(0, 1), "");
+    EXPECT_EQ(reader.readWholeFileAfter(0, 1), "Line 0\nLine 1\nLine 2\nLine 3");
+
+    EXPECT_EQ(reader.readWholeFileBefore(1, 1), "");
+    EXPECT_EQ(reader.readWholeFileAfter(1, 1), "Line 0\nLine 1\nLine 2\nLine 3");
+
+    EXPECT_EQ(reader.readWholeFileBefore(2, 1), "");
+    EXPECT_EQ(reader.readWholeFileAfter(2, 1), "Line 0\nLine 1\nLine 2\nLine 3");
+
+    EXPECT_EQ(reader.readWholeFileBefore(3, 1), "");
+    EXPECT_EQ(reader.readWholeFileAfter(3, 1), "Line 0\nLine 1\nLine 2\nLine 3");
+
+    EXPECT_EQ(reader.readWholeFileBefore(4, 1), "");
+    EXPECT_EQ(reader.readWholeFileAfter(4, 1), "Line 0\nLine 1\nLine 2\nLine 3");
+
+    EXPECT_EQ(reader.readWholeFileBefore(5, 1), "L");
+    EXPECT_EQ(reader.readWholeFileAfter(5, 1), "ine 0\nLine 1\nLine 2\nLine 3");
+
+    EXPECT_EQ(reader.readWholeFileBefore(6, 1), "Line 0\nL");
+    EXPECT_EQ(reader.readWholeFileAfter(6, 1), "ine 1\nLine 2\nLine 3");
+
+    EXPECT_EQ(reader.readWholeFileBefore(7, 1), "Line 0\nLine 1\nL");
+    EXPECT_EQ(reader.readWholeFileAfter(7, 1), "ine 2\nLine 3");
+
+    EXPECT_EQ(reader.readWholeFileBefore(8, 1), "Line 0\nLine 1\nLine 2\nL");
+    EXPECT_EQ(reader.readWholeFileAfter(8, 1), "ine 3");
 }
 
 TEST_F(DocumentContextReaderTest, testFindCopyrightSingleLine)


### PR DESCRIPTION
This commit ensures that copyright information is always excluded and that context is always split into prefix and suffix at correct position.