### PR TITLE
refactor: Move all processing logic to CodeHandler::processText()

### DIFF
--- a/CodeHandler.cpp
+++ b/CodeHandler.cpp
@@ -22,8 +22,12 @@
 
 namespace QodeAssist {
 
-QString CodeHandler::processText(QString text)
+QString CodeHandler::processText(QString text, bool smartProcess)
 {
+    if (!smartProcess) {
+        return text;
+    }
+
     QString result;
     QStringList lines = text.split('\n');
     bool inCodeBlock = false;

--- a/CodeHandler.hpp
+++ b/CodeHandler.hpp
@@ -28,7 +28,7 @@ namespace QodeAssist {
 class CodeHandler
 {
 public:
-    static QString processText(QString text);
+    static QString processText(QString text, bool smartProcess = true);
 
     static QString detectLanguage(const QString &line);
 

--- a/LLMClientInterface.cpp
+++ b/LLMClientInterface.cpp
@@ -293,11 +293,9 @@ void LLMClientInterface::sendCompletionToClient(
 
     LOG_MESSAGE(QString("Completions before filter: \n%1").arg(completion));
 
-    QString processedCompletion
-        = promptTemplate->type() == LLMCore::TemplateType::Chat
-                  && Settings::codeCompletionSettings().smartProcessInstuctText()
-              ? CodeHandler::processText(completion)
-              : completion;
+    bool smartProcess = promptTemplate->type() == LLMCore::TemplateType::Chat
+                        && Settings::codeCompletionSettings().smartProcessInstuctText();
+    QString processedCompletion = CodeHandler::processText(completion, smartProcess);
 
     completionItem[LanguageServerProtocol::textKey] = processedCompletion;
     QJsonObject range;

--- a/test/CodeHandlerTest.cpp
+++ b/test/CodeHandlerTest.cpp
@@ -33,6 +33,15 @@ class CodeHandlerTest : public QObject, public testing::Test
     Q_OBJECT
 };
 
+TEST_F(CodeHandlerTest, testProcessTextNoProcessWithCodeBlock)
+{
+    QString input = "This is a comment\n"
+                    "```python\nprint('Hello, world!')\n```\n"
+                    "Another comment";
+
+    EXPECT_EQ(CodeHandler::processText(input, false), input);
+}
+
 TEST_F(CodeHandlerTest, testProcessTextWithCodeBlock)
 {
     QString input = "This is a comment\n"


### PR DESCRIPTION
This will become useful once more processing modes are available