### PR TITLE
chore: Silence Qt warnings during tests

### DIFF
--- a/test/unittest_main.cpp
+++ b/test/unittest_main.cpp
@@ -19,9 +19,19 @@
 
 #include <gtest/gtest.h>
 #include <QGuiApplication>
+#include <QtGlobal>
+
+void silenceQtWarningNoise(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+{
+    if (msg.startsWith("SOFT ASSERT") || msg.startsWith("Accessing MimeDatabase")) {
+        return;
+    }
+    qt_message_output(type, context, msg);
+}
 
 int main(int argc, char *argv[])
 {
+    qInstallMessageHandler(silenceQtWarningNoise);
     QGuiApplication application(argc, argv);
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
Currently tests emit a lot of warnings like:

Accessing MimeDatabase for text/python before plugins are initialized

or

SOFT ASSERT [<...>]: "theSettings" in <..>/src/libs/utils/aspects.cpp

These make navigating test output difficult. The warnings are mostly useless in tests, so these can be disabled.

If this ever becomes a problem, the code can be enhanced to re-enable tests via environment variable.