### PR TITLE
refactor: Don't use global state in ContextManager::isSpecifyCompletion

### DIFF
--- a/LLMClientInterface.cpp
+++ b/LLMClientInterface.cpp
@@ -161,7 +161,7 @@ void LLMClientInterface::handleCompletion(const QJsonObject &request)
     auto &completeSettings = Settings::codeCompletionSettings();
     auto &generalSettings = Settings::generalSettings();
 
-    bool isPreset1Active = Context::ContextManager::instance().isSpecifyCompletion(request);
+    bool isPreset1Active = Context::ContextManager::isSpecifyCompletion(request, generalSettings);
 
     const auto providerName = !isPreset1Active ? generalSettings.ccProvider()
                                                : generalSettings.ccPreset1Provider();
@@ -280,10 +280,11 @@ LLMCore::ContextData LLMClientInterface::prepareContext(
 void LLMClientInterface::sendCompletionToClient(
     const QString &completion, const QJsonObject &request, bool isComplete)
 {
-    bool isPreset1Active = Context::ContextManager::instance().isSpecifyCompletion(request);
+    auto &generalSettings = Settings::generalSettings();
+    bool isPreset1Active = Context::ContextManager::isSpecifyCompletion(request, generalSettings);
 
-    auto templateName = !isPreset1Active ? Settings::generalSettings().ccTemplate()
-                                         : Settings::generalSettings().ccPreset1Template();
+    auto templateName = !isPreset1Active ? generalSettings.ccTemplate()
+                                         : generalSettings.ccPreset1Template();
 
     auto promptTemplate = LLMCore::PromptTemplateManager::instance().getFimTemplateByName(
         templateName);

--- a/context/ContextManager.cpp
+++ b/context/ContextManager.cpp
@@ -70,7 +70,7 @@ ContentFile ContextManager::createContentFile(const QString &filePath) const
     return contentFile;
 }
 
-ProgrammingLanguage ContextManager::getDocumentLanguage(const QJsonObject &request) const
+ProgrammingLanguage ContextManager::getDocumentLanguage(const QJsonObject &request)
 {
     QJsonObject params = request["params"].toObject();
     QJsonObject doc = params["doc"].toObject();
@@ -88,10 +88,9 @@ ProgrammingLanguage ContextManager::getDocumentLanguage(const QJsonObject &reque
     return Context::ProgrammingLanguageUtils::fromMimeType(textDocument->mimeType());
 }
 
-bool ContextManager::isSpecifyCompletion(const QJsonObject &request)
+bool ContextManager::isSpecifyCompletion(
+    const QJsonObject &request, const Settings::GeneralSettings &generalSettings)
 {
-    auto &generalSettings = Settings::generalSettings();
-
     Context::ProgrammingLanguage documentLanguage = getDocumentLanguage(request);
     Context::ProgrammingLanguage preset1Language = Context::ProgrammingLanguageUtils::fromString(
         generalSettings.preset1Language.displayForIndex(generalSettings.preset1Language()));

--- a/context/ContextManager.hpp
+++ b/context/ContextManager.hpp
@@ -24,6 +24,7 @@
 
 #include "ContentFile.hpp"
 #include "ProgrammingLanguage.hpp"
+#include "settings/GeneralSettings.hpp"
 
 namespace QodeAssist::Context {
 
@@ -35,8 +36,10 @@ public:
     static ContextManager &instance();
     QString readFile(const QString &filePath) const;
     QList<ContentFile> getContentFiles(const QStringList &filePaths) const;
-    ProgrammingLanguage getDocumentLanguage(const QJsonObject &request) const;
-    bool isSpecifyCompletion(const QJsonObject &request);
+
+    static ProgrammingLanguage getDocumentLanguage(const QJsonObject &request);
+    static bool isSpecifyCompletion(
+        const QJsonObject &request, const Settings::GeneralSettings &generalSettings);
 
 private:
     explicit ContextManager(QObject *parent = nullptr);


### PR DESCRIPTION
Using global state makes testing things way harder.