### PR TITLE
refactor: Inject settings into LLMClientInterface

### DIFF
--- a/LLMClientInterface.hpp
+++ b/LLMClientInterface.hpp
@@ -25,6 +25,8 @@
 #include <context/ProgrammingLanguage.hpp>
 #include <llmcore/ContextData.hpp>
 #include <llmcore/RequestHandler.hpp>
+#include <settings/CodeCompletionSettings.hpp>
+#include <settings/GeneralSettings.hpp>
 
 class QNetworkReply;
 class QNetworkAccessManager;
@@ -36,7 +38,9 @@ class LLMClientInterface : public LanguageClient::BaseClientInterface
     Q_OBJECT
 
 public:
-    LLMClientInterface();
+    LLMClientInterface(
+        const Settings::GeneralSettings &generalSettings,
+        const Settings::CodeCompletionSettings &completeSettings);
 
     Utils::FilePath serverDeviceTemplate() const override;
 
@@ -61,6 +65,8 @@ private:
     LLMCore::ContextData prepareContext(
         const QJsonObject &request, const QStringView &accumulatedCompletion = QString{});
 
+    const Settings::CodeCompletionSettings &m_completeSettings;
+    const Settings::GeneralSettings &m_generalSettings;
     LLMCore::RequestHandler m_requestHandler;
     QElapsedTimer m_completionTimer;
     QMap<QString, qint64> m_requestStartTimes;

--- a/QodeAssistClient.cpp
+++ b/QodeAssistClient.cpp
@@ -45,7 +45,8 @@ using namespace Core;
 namespace QodeAssist {
 
 QodeAssistClient::QodeAssistClient()
-    : LanguageClient::Client(new LLMClientInterface())
+    : LanguageClient::Client(
+          new LLMClientInterface(Settings::generalSettings(), Settings::codeCompletionSettings()))
     , m_recentCharCount(0)
 {
     setName("Qode Assist");

--- a/settings/CodeCompletionSettings.cpp
+++ b/settings/CodeCompletionSettings.cpp
@@ -358,7 +358,7 @@ void CodeCompletionSettings::resetSettingsToDefaults()
     }
 }
 
-QString CodeCompletionSettings::processMessageToFIM(const QString &prefix, const QString &suffix)
+QString CodeCompletionSettings::processMessageToFIM(const QString &prefix, const QString &suffix) const
 {
     QString result = userMessageTemplateForCC();
     result.replace("${prefix}", prefix);

--- a/settings/CodeCompletionSettings.hpp
+++ b/settings/CodeCompletionSettings.hpp
@@ -79,7 +79,7 @@ public:
     // API Configuration Settings
     Utils::StringAspect apiKey{this};
 
-    QString processMessageToFIM(const QString &prefix, const QString &suffix);
+    QString processMessageToFIM(const QString &prefix, const QString &suffix) const;
 
 private:
     void setupConnections();


### PR DESCRIPTION
This reduces reliance on global state and makes it more possible to test the code.