### PR TITLE
chore: Replace deprecated FilePath::toString() with toFSPathString()

### DIFF
--- a/ChatView/ChatRootView.cpp
+++ b/ChatView/ChatRootView.cpp
@@ -164,9 +164,10 @@ QString ChatRootView::getChatsHistoryDir() const
 
     if (auto project = ProjectExplorer::ProjectManager::startupProject()) {
         Settings::ProjectSettings projectSettings(project);
-        path = projectSettings.chatHistoryPath().toString();
+        path = projectSettings.chatHistoryPath().toFSPathString();
     } else {
-        path = QString("%1/qodeassist/chat_history").arg(Core::ICore::userResourcePath().toString());
+        path = QString("%1/qodeassist/chat_history")
+                   .arg(Core::ICore::userResourcePath().toFSPathString());
     }
 
     QDir dir(path);
@@ -350,7 +351,7 @@ void ChatRootView::showAttachFilesDialog()
     dialog.setFileMode(QFileDialog::ExistingFiles);
 
     if (auto project = ProjectExplorer::ProjectManager::startupProject()) {
-        dialog.setDirectory(project->projectDirectory().toString());
+        dialog.setDirectory(project->projectDirectory().toFSPathString());
     }
 
     if (dialog.exec() == QDialog::Accepted) {
@@ -384,7 +385,7 @@ void ChatRootView::showLinkFilesDialog()
     dialog.setFileMode(QFileDialog::ExistingFiles);
 
     if (auto project = ProjectExplorer::ProjectManager::startupProject()) {
-        dialog.setDirectory(project->projectDirectory().toString());
+        dialog.setDirectory(project->projectDirectory().toFSPathString());
     }
 
     if (dialog.exec() == QDialog::Accepted) {
@@ -437,9 +438,10 @@ void ChatRootView::openChatHistoryFolder()
     QString path;
     if (auto project = ProjectExplorer::ProjectManager::startupProject()) {
         Settings::ProjectSettings projectSettings(project);
-        path = projectSettings.chatHistoryPath().toString();
+        path = projectSettings.chatHistoryPath().toFSPathString();
     } else {
-        path = QString("%1/qodeassist/chat_history").arg(Core::ICore::userResourcePath().toString());
+        path = QString("%1/qodeassist/chat_history")
+                   .arg(Core::ICore::userResourcePath().toFSPathString());
     }
 
     QDir dir(path);
@@ -493,7 +495,7 @@ bool ChatRootView::isSyncOpenFiles() const
 void ChatRootView::onEditorAboutToClose(Core::IEditor *editor)
 {
     if (auto document = editor->document(); document && isSyncOpenFiles()) {
-        QString filePath = document->filePath().toString();
+        QString filePath = document->filePath().toFSPathString();
         m_linkedFiles.removeOne(filePath);
         emit linkedFilesChanged();
     }
@@ -506,7 +508,7 @@ void ChatRootView::onEditorAboutToClose(Core::IEditor *editor)
 void ChatRootView::onAppendLinkFileFromEditor(Core::IEditor *editor)
 {
     if (auto document = editor->document(); document && isSyncOpenFiles()) {
-        QString filePath = document->filePath().toString();
+        QString filePath = document->filePath().toFSPathString();
         if (!m_linkedFiles.contains(filePath)) {
             m_linkedFiles.append(filePath);
             emit linkedFilesChanged();

--- a/ChatView/ClientInterface.cpp
+++ b/ChatView/ClientInterface.cpp
@@ -183,11 +183,11 @@ QString ClientInterface::getCurrentFileContext() const
     }
 
     QString fileInfo = QString("Language: %1\nFile: %2\n\n")
-                           .arg(textDocument->mimeType(), textDocument->filePath().toString());
+                           .arg(textDocument->mimeType(), textDocument->filePath().toFSPathString());
 
     QString content = textDocument->document()->toPlainText();
 
-    LOG_MESSAGE(QString("Got context from file: %1").arg(textDocument->filePath().toString()));
+    LOG_MESSAGE(QString("Got context from file: %1").arg(textDocument->filePath().toFSPathString()));
 
     return QString("Current file context:\n%1\nFile content:\n%2").arg(fileInfo, content);
 }

--- a/context/ContextManager.cpp
+++ b/context/ContextManager.cpp
@@ -81,7 +81,7 @@ ProgrammingLanguage ContextManager::getDocumentLanguage(const QJsonObject &reque
         filePath);
 
     if (!textDocument) {
-        LOG_MESSAGE("Error: Document is not available for" + filePath.toString());
+        LOG_MESSAGE("Error: Document is not available for" + filePath.toFSPathString());
         return Context::ProgrammingLanguage::Unknown;
     }
 

--- a/settings/ProjectSettings.cpp
+++ b/settings/ProjectSettings.cpp
@@ -43,8 +43,8 @@ ProjectSettings::ProjectSettings(ProjectExplorer::Project *project)
     chatHistoryPath.setExpectedKind(Utils::PathChooser::ExistingDirectory);
     chatHistoryPath.setLabelText(Tr::tr("Chat History Path:"));
 
-    QString projectChatHistoryPath
-        = QString("%1/qodeassist/chat_history").arg(Core::ICore::userResourcePath().toString());
+    QString projectChatHistoryPath = QString("%1/qodeassist/chat_history")
+                                         .arg(Core::ICore::userResourcePath().toFSPathString());
 
     chatHistoryPath.setDefaultValue(projectChatHistoryPath);
 


### PR DESCRIPTION
This solves a number of deprecation warnings during build. FilePath::toFSPathString() has been available since couple of years ago.