### PR TITLE
refactor: Pass LLMClientInterface to QodeAssistClient

### DIFF
--- a/QodeAssistClient.cpp
+++ b/QodeAssistClient.cpp
@@ -44,13 +44,8 @@ using namespace Core;
 
 namespace QodeAssist {
 
-QodeAssistClient::QodeAssistClient(
-    LLMCore::IProviderRegistry &providerRegistry, LLMCore::IPromptProvider *promptProvider)
-    : LanguageClient::Client(new LLMClientInterface(
-          Settings::generalSettings(),
-          Settings::codeCompletionSettings(),
-          providerRegistry,
-          promptProvider))
+QodeAssistClient::QodeAssistClient(LLMClientInterface *clientInterface)
+    : LanguageClient::Client(clientInterface)
     , m_recentCharCount(0)
 {
     setName("Qode Assist");

--- a/QodeAssistClient.hpp
+++ b/QodeAssistClient.hpp
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "LLMClientInterface.hpp"
 #include "LSPCompletion.hpp"
 #include <languageclient/client.h>
 #include <llmcore/IPromptProvider.hpp>
@@ -34,8 +35,7 @@ namespace QodeAssist {
 class QodeAssistClient : public LanguageClient::Client
 {
 public:
-    explicit QodeAssistClient(
-        LLMCore::IProviderRegistry &providerRegistry, LLMCore::IPromptProvider *promptProvider);
+    explicit QodeAssistClient(LLMClientInterface *clientInterface);
     ~QodeAssistClient() override;
 
     void openDocument(TextEditor::TextDocument *document) override;

--- a/qodeassist.cpp
+++ b/qodeassist.cpp
@@ -138,8 +138,11 @@ public:
     void restartClient()
     {
         LanguageClient::LanguageClientManager::shutdownClient(m_qodeAssistClient);
-        m_qodeAssistClient
-            = new QodeAssistClient(LLMCore::ProvidersManager::instance(), &m_promptProvider);
+        m_qodeAssistClient = new QodeAssistClient(new LLMClientInterface(
+            Settings::generalSettings(),
+            Settings::codeCompletionSettings(),
+            LLMCore::ProvidersManager::instance(),
+            &m_promptProvider));
     }
 
     bool delayedInitialize() final


### PR DESCRIPTION
Contructing LLMClientInterface in constructor of QodeAssistClient when initializing base class severely limits what can be done. In particular, no members can be referred to, because nothing of the class instance itself has been initialized at that point of time.