### PR TITLE
refactor: Extract performance logging to separate class

### DIFF
--- a/LLMClientInterface.hpp
+++ b/LLMClientInterface.hpp
@@ -27,6 +27,7 @@
 #include <llmcore/IPromptProvider.hpp>
 #include <llmcore/IProviderRegistry.hpp>
 #include <llmcore/RequestHandler.hpp>
+#include <logger/IRequestPerformanceLogger.hpp>
 #include <settings/CodeCompletionSettings.hpp>
 #include <settings/GeneralSettings.hpp>
 
@@ -44,7 +45,8 @@ public:
         const Settings::GeneralSettings &generalSettings,
         const Settings::CodeCompletionSettings &completeSettings,
         LLMCore::IProviderRegistry &providerRegistry,
-        LLMCore::IPromptProvider *promptProvider);
+        LLMCore::IPromptProvider *promptProvider,
+        IRequestPerformanceLogger &performanceLogger);
 
     Utils::FilePath serverDeviceTemplate() const override;
 
@@ -74,12 +76,8 @@ private:
     LLMCore::IPromptProvider *m_promptProvider = nullptr;
     LLMCore::IProviderRegistry &m_providerRegistry;
     LLMCore::RequestHandler m_requestHandler;
+    IRequestPerformanceLogger &m_performanceLogger;
     QElapsedTimer m_completionTimer;
-    QMap<QString, qint64> m_requestStartTimes;
-
-    void startTimeMeasurement(const QString &requestId);
-    void endTimeMeasurement(const QString &requestId);
-    void logPerformance(const QString &requestId, const QString &operation, qint64 elapsedMs);
 };
 
 } // namespace QodeAssist

--- a/logger/CMakeLists.txt
+++ b/logger/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_library(QodeAssistLogger STATIC
+    EmptyRequestPerformanceLogger.hpp
+    IRequestPerformanceLogger.hpp
     Logger.cpp
     Logger.hpp
+    RequestPerformanceLogger.hpp RequestPerformanceLogger.cpp
 )
 
 target_link_libraries(QodeAssistLogger

--- a/logger/EmptyRequestPerformanceLogger.hpp
+++ b/logger/EmptyRequestPerformanceLogger.hpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 Povilas Kanapickas <povilas@radix.lt>
+ *
+ * This file is part of QodeAssist.
+ *
+ * QodeAssist is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QodeAssist is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QodeAssist. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "IRequestPerformanceLogger.hpp"
+
+namespace QodeAssist {
+
+class EmptyRequestPerformanceLogger : public IRequestPerformanceLogger
+{
+public:
+    void startTimeMeasurement(const QString &requestId) override {}
+    void endTimeMeasurement(const QString &requestId) override {}
+    void logPerformance(const QString &requestId, qint64 elapsedMs) override {}
+};
+
+} // namespace QodeAssist

--- a/logger/IRequestPerformanceLogger.hpp
+++ b/logger/IRequestPerformanceLogger.hpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Povilas Kanapickas <povilas@radix.lt>
+ *
+ * This file is part of QodeAssist.
+ *
+ * QodeAssist is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QodeAssist is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QodeAssist. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QString>
+
+namespace QodeAssist {
+
+class IRequestPerformanceLogger
+{
+public:
+    virtual ~IRequestPerformanceLogger() = default;
+
+    virtual void startTimeMeasurement(const QString &requestId) = 0;
+    virtual void endTimeMeasurement(const QString &requestId) = 0;
+    virtual void logPerformance(const QString &requestId, qint64 elapsedMs) = 0;
+};
+
+} // namespace QodeAssist

--- a/logger/RequestPerformanceLogger.cpp
+++ b/logger/RequestPerformanceLogger.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 Povilas Kanapickas <povilas@radix.lt>
+ *
+ * This file is part of QodeAssist.
+ *
+ * QodeAssist is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QodeAssist is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QodeAssist. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "RequestPerformanceLogger.hpp"
+#include "Logger.hpp"
+
+namespace QodeAssist {
+
+void RequestPerformanceLogger::startTimeMeasurement(const QString &requestId)
+{
+    m_requestStartTimes[requestId] = QDateTime::currentMSecsSinceEpoch();
+}
+
+void RequestPerformanceLogger::endTimeMeasurement(const QString &requestId)
+{
+    if (!m_requestStartTimes.contains(requestId)) {
+        return;
+    }
+
+    qint64 startTime = m_requestStartTimes[requestId];
+    qint64 endTime = QDateTime::currentMSecsSinceEpoch();
+    qint64 totalTime = endTime - startTime;
+    logPerformance(requestId, totalTime);
+    m_requestStartTimes.remove(requestId);
+}
+
+void RequestPerformanceLogger::logPerformance(const QString &requestId, qint64 elapsedMs)
+{
+    LOG_MESSAGE(
+        QString("Performance: %1 total completion time took %2 ms").arg(requestId).arg(elapsedMs));
+}
+
+void RequestPerformanceLogger::logPerformance(
+    const QString &requestId, const QString &operation, qint64 elapsedMs)
+{
+    LOG_MESSAGE(QString("Performance: %1 %2 took %3 ms").arg(requestId, operation).arg(elapsedMs));
+}
+
+} // namespace QodeAssist

--- a/logger/RequestPerformanceLogger.hpp
+++ b/logger/RequestPerformanceLogger.hpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 Povilas Kanapickas <povilas@radix.lt>
+ *
+ * This file is part of QodeAssist.
+ *
+ * QodeAssist is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QodeAssist is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QodeAssist. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "IRequestPerformanceLogger.hpp"
+#include <QDateTime>
+#include <QMap>
+
+namespace QodeAssist {
+
+class RequestPerformanceLogger : public IRequestPerformanceLogger
+{
+public:
+    RequestPerformanceLogger() = default;
+    ~RequestPerformanceLogger() override = default;
+
+    void startTimeMeasurement(const QString &requestId) override;
+    void endTimeMeasurement(const QString &requestId) override;
+    void logPerformance(const QString &requestId, qint64 elapsedMs) override;
+    void logPerformance(const QString &requestId, const QString &operation, qint64 elapsedMs);
+
+private:
+    QMap<QString, qint64> m_requestStartTimes;
+};
+
+} // namespace QodeAssist

--- a/qodeassist.cpp
+++ b/qodeassist.cpp
@@ -48,6 +48,7 @@
 #include "chat/NavigationPanel.hpp"
 #include "llmcore/PromptProviderFim.hpp"
 #include "llmcore/ProvidersManager.hpp"
+#include "logger/RequestPerformanceLogger.hpp"
 #include "settings/GeneralSettings.hpp"
 #include "settings/ProjectSettingsPanel.hpp"
 #include "settings/SettingsConstants.hpp"
@@ -142,7 +143,8 @@ public:
             Settings::generalSettings(),
             Settings::codeCompletionSettings(),
             LLMCore::ProvidersManager::instance(),
-            &m_promptProvider));
+            &m_promptProvider,
+            m_performanceLogger));
     }
 
     bool delayedInitialize() final
@@ -184,6 +186,7 @@ private:
 
     QPointer<QodeAssistClient> m_qodeAssistClient;
     LLMCore::PromptProviderFim m_promptProvider;
+    RequestPerformanceLogger m_performanceLogger;
     QPointer<Chat::ChatOutputPane> m_chatOutputPane;
     QPointer<Chat::NavigationPanel> m_navigationPanel;
     QPointer<PluginUpdater> m_updater;


### PR DESCRIPTION
This should not be responsibility of LLMClientInterface. Extracting this class also adds flexibility to silence logging output in tests.