### PR TITLE
refactor: Extract document reading to separate class

### DIFF
--- a/LLMClientInterface.hpp
+++ b/LLMClientInterface.hpp
@@ -22,6 +22,7 @@
 #include <languageclient/languageclientinterface.h>
 #include <texteditor/texteditor.h>
 
+#include <context/IDocumentReader.hpp>
 #include <context/ProgrammingLanguage.hpp>
 #include <llmcore/ContextData.hpp>
 #include <llmcore/IPromptProvider.hpp>
@@ -47,6 +48,7 @@ public:
         LLMCore::IProviderRegistry &providerRegistry,
         LLMCore::IPromptProvider *promptProvider,
         LLMCore::RequestHandlerBase &requestHandler,
+        Context::IDocumentReader &documentReader,
         IRequestPerformanceLogger &performanceLogger);
 
     Utils::FilePath serverDeviceTemplate() const override;
@@ -77,6 +79,7 @@ private:
     LLMCore::IPromptProvider *m_promptProvider = nullptr;
     LLMCore::IProviderRegistry &m_providerRegistry;
     LLMCore::RequestHandlerBase &m_requestHandler;
+    Context::IDocumentReader &m_documentReader;
     IRequestPerformanceLogger &m_performanceLogger;
     QElapsedTimer m_completionTimer;
 };

--- a/context/CMakeLists.txt
+++ b/context/CMakeLists.txt
@@ -3,6 +3,8 @@ add_library(Context STATIC
     ChangesManager.h ChangesManager.cpp
     ContextManager.hpp ContextManager.cpp
     ContentFile.hpp
+    DocumentReaderQtCreator.hpp
+    IDocumentReader.hpp
     TokenUtils.hpp TokenUtils.cpp
     ProgrammingLanguage.hpp ProgrammingLanguage.cpp
 )

--- a/context/DocumentReaderQtCreator.hpp
+++ b/context/DocumentReaderQtCreator.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 Povilas Kanapickas
+ *
+ * This file is part of QodeAssist.
+ *
+ * QodeAssist is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QodeAssist is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QodeAssist. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "IDocumentReader.hpp"
+
+#include <texteditor/textdocument.h>
+
+namespace QodeAssist::Context {
+
+class DocumentReaderQtCreator : public IDocumentReader
+{
+public:
+    DocumentInfo readDocument(const QString &path) const override
+    {
+        auto *textDocument = TextEditor::TextDocument::textDocumentForFilePath(
+            Utils::FilePath::fromString(path));
+        if (!textDocument) {
+            return {};
+        }
+        return {
+            .document = textDocument->document(),
+            .mimeType = textDocument->mimeType(),
+            .filePath = path};
+    }
+};
+
+} // namespace QodeAssist::Context

--- a/context/IDocumentReader.hpp
+++ b/context/IDocumentReader.hpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 Povilas Kanapickas
+ *
+ * This file is part of QodeAssist.
+ *
+ * QodeAssist is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QodeAssist is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QodeAssist. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QTextDocument>
+
+namespace QodeAssist::Context {
+
+struct DocumentInfo
+{
+    QTextDocument *document = nullptr; // not owned
+    QString mimeType;
+    QString filePath;
+};
+
+class IDocumentReader
+{
+public:
+    virtual ~IDocumentReader() = default;
+
+    virtual DocumentInfo readDocument(const QString &path) const = 0;
+};
+
+} // namespace QodeAssist::Context

--- a/qodeassist.cpp
+++ b/qodeassist.cpp
@@ -46,6 +46,7 @@
 #include "Version.hpp"
 #include "chat/ChatOutputPane.h"
 #include "chat/NavigationPanel.hpp"
+#include "context/DocumentReaderQtCreator.hpp"
 #include "llmcore/PromptProviderFim.hpp"
 #include "llmcore/ProvidersManager.hpp"
 #include "logger/RequestPerformanceLogger.hpp"
@@ -146,6 +147,7 @@ public:
             LLMCore::ProvidersManager::instance(),
             &m_promptProvider,
             m_requestHandler,
+            m_documentReader,
             m_performanceLogger));
     }
 
@@ -189,6 +191,7 @@ private:
     QPointer<QodeAssistClient> m_qodeAssistClient;
     LLMCore::PromptProviderFim m_promptProvider;
     LLMCore::RequestHandler m_requestHandler{this};
+    Context::DocumentReaderQtCreator m_documentReader;
     RequestPerformanceLogger m_performanceLogger;
     QPointer<Chat::ChatOutputPane> m_chatOutputPane;
     QPointer<Chat::NavigationPanel> m_navigationPanel;


### PR DESCRIPTION
This decouples LLMClientInterface from Qt Creator text editor implementation and allows to write tests