### PR TITLE
chore: Checkout submodules when building

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -264,6 +264,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: recursive
     - uses: actions/setup-node@v4
       with:
         node-version: '20'


### PR DESCRIPTION
This will be needed for when projects starts to use 3rdparty/inja for real.