### PR TITLE
fix: Resolve thread-related QNetworkAccessManager issue

### DIFF
--- a/llmcore/RequestHandler.hpp
+++ b/llmcore/RequestHandler.hpp
@@ -40,7 +40,6 @@ public:
     void handleLLMResponse(QNetworkReply *reply, const QJsonObject &request, const LLMConfig &config);
 
 private:
-    QNetworkAccessManager *m_manager;
     QMap<QString, QNetworkReply *> m_activeRequests;
     QMap<QNetworkReply *, QString> m_accumulatedResponses;
 


### PR DESCRIPTION
Fixes "QObject: Cannot create children for a parent that is in a different thread" error by creating QNetworkAccessManager in the same thread where it's used, ensuring proper thread affinity for network operations.