### PR TITLE
feat: Merge suggestion with existing code if it looks similar

### DIFF
--- a/LLMSuggestion.cpp
+++ b/LLMSuggestion.cpp
@@ -278,21 +278,16 @@ bool LLMSuggestion::apply()
             QString restOfText = text.mid(firstLineEnd);
             editCursor.insertText(mergedFirstLine + restOfText);
         } else {
-            for (int i = 0; i < toReplace; ++i)
-                editCursor.movePosition(QTextCursor::Down, QTextCursor::KeepAnchor);
+            editCursor.movePosition(QTextCursor::Down, QTextCursor::KeepAnchor, toReplace);
             editCursor.movePosition(QTextCursor::EndOfLine, QTextCursor::KeepAnchor);
 
             QTextCursor lastLineCursor = editCursor;
-            lastLineCursor.setPosition(lastLineCursor.position(), QTextCursor::MoveAnchor);
-            lastLineCursor.movePosition(QTextCursor::StartOfLine, QTextCursor::KeepAnchor);
+            lastLineCursor.select(QTextCursor::LineUnderCursor);
             QString lastExistingLine = lastLineCursor.selectedText();
 
             QString lastSuggestedLine = text.mid(text.lastIndexOf('\n') + 1);
-            qDebug() << lastExistingLine;
-            qDebug() << lastSuggestedLine;
 
             QString tail = existingTailToKeep(lastSuggestedLine, lastExistingLine);
-            qDebug() << tail;
             editCursor.insertText(text + tail);
         }
     } else {


### PR DESCRIPTION
Hi!

This is something like what I meant in #152 .

It doesn't affect representation. During full suggestion apply, it searches for the next rows that look similar to the applied text. If they are similar enough (this should be configurable, perhaps) it replaces the found rows with suggested.

![Suggestion](https://github.com/user-attachments/assets/532a7871-5e18-4e2b-b88c-198bb84a3482)

![Apply result](https://github.com/user-attachments/assets/4790822a-9a1b-4ae4-8c4e-e7b7a2fa7ca1)

No real use in this example though :)