### PR TITLE
fix: enables the send message shortcut only for active chat

### DIFF
--- a/ChatView/qml/RootItem.qml
+++ b/ChatView/qml/RootItem.qml
@@ -514,11 +514,8 @@ ChatRootView {
 
         sequences: ["Ctrl+Return", "Ctrl+Enter"]
         context: Qt.WindowShortcut
-        onActivated: {
-            if (messageInput.activeFocus && !Qt.inputMethod.visible && !fileMentionPopup.visible) {
-                root.sendChatMessage()
-            }
-        }
+        enabled: messageInput.activeFocus && !Qt.inputMethod.visible && !fileMentionPopup.visible
+        onActivated: root.sendChatMessage()
     }
 
     function clearChat() {


### PR DESCRIPTION
Multiple instances of the `Shortcut` component with same `sequence` (or `sequences`) property value are ambiguous and `Shortcut::activated` signal doesn't emitted for all these instances.
To fix this issue I've decided to use `Shortcut::enabled` property to enable `Shortcut` instance only for active (having active focus) chat view (`navigation`, `output` or separate window).