### PR TITLE
refactor: Refactors `AgentRoleDialog`'s modes handling

### DIFF
--- a/settings/AgentRoleDialog.cpp
+++ b/settings/AgentRoleDialog.cpp
@@ -29,21 +29,24 @@
 
 namespace QodeAssist::Settings {
 
-AgentRoleDialog::AgentRoleDialog(QWidget *parent)
-    : QDialog(parent)
-    , m_editMode(false)
+AgentRoleDialog::AgentRoleDialog(Action action, QWidget *parent)
+    : QDialog{parent}
+    , m_action{action}
 {
-    setWindowTitle(tr("Add Agent Role"));
-    setupUI();
-}
+    auto getTitle = [](Action action) {
+        switch(action)
+        {
+        case Action::Add:
+            return tr("Add Agent Role");
+        case Action::Duplicate:
+            return tr("Duplicate Agent Role");
+        case Action::Edit:
+            return tr("Edit Agent Role");
+        }
+    };
 
-AgentRoleDialog::AgentRoleDialog(const AgentRole &role, bool editMode, QWidget *parent)
-    : QDialog(parent)
-    , m_editMode(editMode)
-{
-    setWindowTitle(editMode ? tr("Edit Agent Role") : tr("Duplicate Agent Role"));
+    setWindowTitle(getTitle(action));
     setupUI();
-    setRole(role);
 }
 
 void AgentRoleDialog::setupUI()
@@ -83,7 +86,7 @@ void AgentRoleDialog::setupUI()
     connect(m_idEdit, &QLineEdit::textChanged, this, &AgentRoleDialog::validateInput);
     connect(m_systemPromptEdit, &QTextEdit::textChanged, this, &AgentRoleDialog::validateInput);
 
-    if (m_editMode) {
+    if (m_action == Action::Edit) {
         m_idEdit->setEnabled(false);
         m_idEdit->setToolTip(tr("ID cannot be changed for existing roles"));
     }

--- a/settings/AgentRoleDialog.hpp
+++ b/settings/AgentRoleDialog.hpp
@@ -34,8 +34,18 @@ class AgentRoleDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit AgentRoleDialog(QWidget *parent = nullptr);
-    explicit AgentRoleDialog(const AgentRole &role, bool editMode = true, QWidget *parent = nullptr);
+    enum class Action {
+        Add,
+        Duplicate,
+        Edit,
+    };
+
+    explicit AgentRoleDialog(Action action, QWidget *parent = nullptr);
+    explicit AgentRoleDialog(const AgentRole &role, Action action, QWidget *parent = nullptr)
+        : AgentRoleDialog{action, parent}
+    {
+        setRole(role);
+    }
 
     AgentRole getRole() const;
     void setRole(const AgentRole &role);
@@ -49,7 +59,7 @@ private:
     QTextEdit *m_descriptionEdit = nullptr;
     QTextEdit *m_systemPromptEdit = nullptr;
     QDialogButtonBox *m_buttonBox = nullptr;
-    bool m_editMode = false;
+    Action m_action;
 };
 
 } // namespace QodeAssist::Settings

--- a/settings/AgentRolesWidget.cpp
+++ b/settings/AgentRolesWidget.cpp
@@ -129,7 +129,7 @@ void AgentRolesWidget::updateButtons()
 
 void AgentRolesWidget::onAddRole()
 {
-    AgentRoleDialog dialog(this);
+    AgentRoleDialog dialog{AgentRoleDialog::Action::Add, this};
     if (dialog.exec() != QDialog::Accepted)
         return;
 
@@ -170,7 +170,7 @@ void AgentRolesWidget::onEditRole()
         return;
     }
 
-    AgentRoleDialog dialog(role, true, this);
+    AgentRoleDialog dialog{role, AgentRoleDialog::Action::Edit, this};
     if (dialog.exec() != QDialog::Accepted)
         return;
 
@@ -203,7 +203,7 @@ void AgentRolesWidget::onDuplicateRole()
         role.id = baseId + QString::number(counter++);
     }
 
-    AgentRoleDialog dialog(role, false, this);
+    AgentRoleDialog dialog{role, AgentRoleDialog::Action::Duplicate, this};
     if (dialog.exec() != QDialog::Accepted)
         return;
 


### PR DESCRIPTION
This pull request was started from fixing `undefined-bool-conversion` compilation warning and ends up with refactoring the way the `AgentRoleDialog` class handles its mode of operation (Add, Edit, Duplicate) by introducing a new `Action` enum and updating constructors and usages throughout the codebase. This change improves clarity, type safety, and maintainability by replacing the previous use of a boolean flag and implicit logic with explicit action types.
