### PR TITLE
fix: Open Qt Creator settings delayed from `ChatRootView`

### DIFF
--- a/ChatView/ChatRootView.cpp
+++ b/ChatView/ChatRootView.cpp
@@ -750,7 +750,10 @@ void ChatRootView::openRulesFolder()
 
 void ChatRootView::openSettings()
 {
-    Settings::showSettings(Constants::QODE_ASSIST_CHAT_ASSISTANT_SETTINGS_PAGE_ID);
+    QMetaObject::invokeMethod(
+        this,
+        []() { Settings::showSettings(Constants::QODE_ASSIST_CHAT_ASSISTANT_SETTINGS_PAGE_ID); },
+        Qt::QueuedConnection);
 }
 
 void ChatRootView::openFileInEditor(const QString &filePath)


### PR DESCRIPTION
Opening Qt Creator's settings from QodeAssist chat located in navigation or output panels cause an its crash.
To fix it `openSettings` method of `ChatRootView` was updated to ensure that IDE settings are opened later on event loop outside of currently processed event includes `openSettings` call.